### PR TITLE
Updated IRC links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ We're happy you want to contribute! You can help us in different ways:
 
 [3]: https://github.com/cablelabs/snaps-boot/issues
 [4]: https://github.com/cablelabs/snaps-boot/tree/master/doc
-[5]: https://www.irccloud.com/invite?channel=%23cablelabs-snaps&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1
+[5]: http://webchat.freenode.net/?channels=cablelabs-snaps
 
 To submit a pull request, [fork][6] the [SNAPS-Boot repository][7] and then
 [clone][8] your fork:

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ We use an [Apache 2.0 License](LICENSE) for SNAPS-Boot.
 
 Questions? Just send us an email at
 [snaps@cablelabs.com](mailto:snaps@cablelabs.com) or join the conversation:
-[![IRC](https://www.irccloud.com/invite-svg?channel=%23cablelabs-snaps&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1)](https://www.irccloud.com/invite?channel=%23cablelabs-snaps&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1).
+[![IRC](https://www.irccloud.com/invite-svg?channel=%23cablelabs-snaps&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1)](http://webchat.freenode.net/?channels=cablelabs-snaps).


### PR DESCRIPTION
#### What does this PR do?
Updates the IRC links to point to freenode so users don't need to create accounts.
#### Where should the reviewer start?
Changes in README.md and CONTRIBUTING.md only.
#### How should this be manually tested?
NA
#### Any background context you want to provide?
This was a suggestion by @RandyLevensalor 
#### Screenshots (if appropriate)
NA
#### Questions:
- Have you connected this PR to the issue it fixes? Yes.
- Does the documentation need an update? No (this does it).
- Does this add new Python dependencies? No.