### PR TITLE
Enable nested kvm

### DIFF
--- a/conf/pxe_cluster/ks.cfg
+++ b/conf/pxe_cluster/ks.cfg
@@ -145,3 +145,9 @@ server 172.16.141.17 iburst
 EOF
 
 %end
+
+%post
+cat >> /etc/modprobe.d/nest.conf <<EOF
+options kvm_intel nested=1
+EOF
+%end


### PR DESCRIPTION
Issue: 74

#### What does this PR do?
Enables nested virtualization at box build time for all nodes. Should be No-Op on AMD boxes.

#### Do you have any concerns with this PR?
None.

#### How can the reviewer verify this PR?
After merging this request, rebuild your snaps-boot and then check the status on the kvm_intel module:
cat /sys/module/kvm_intel/parameters/nested
and validate that it displays "Y" for yes.

#### Any background context you want to provide?
Nested virtualization allows much better performance for Openstack on Openstack (or any other nested virtualization usage, libvirt, snaps on snaps, etc.)

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
Yes, Issue 74
- Does the documentation need an update?
Uncertain

- Does this add new Python dependencies?
No.

- Have you added unit or functional tests for this PR?
No