### PR TITLE
Remove the India (in.) prefix from the apt repositories.

### DIFF
--- a/conf/pxe_cluster/ks.cfg
+++ b/conf/pxe_cluster/ks.cfg
@@ -65,45 +65,45 @@ Acquire::ftp::Proxy "";
 EOF
 
 cat > /etc/apt/sources.list <<EOF
-# deb http://in.archive.ubuntu.com/ubuntu/ xenial main restricted
+# deb http://archive.ubuntu.com/ubuntu/ xenial main restricted
 
-# deb http://in.archive.ubuntu.com/ubuntu/ xenial-updates main restricted
+# deb http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted
 # deb http://security.ubuntu.com/ubuntu xenial-security main restricted
 
 # See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
 # newer versions of the distribution.
-deb http://in.archive.ubuntu.com/ubuntu/ xenial main restricted
-# deb-src http://in.archive.ubuntu.com/ubuntu/ xenial main restricted
+deb http://archive.ubuntu.com/ubuntu/ xenial main restricted
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial main restricted
 
 ## Major bug fix updates produced after the final release of the
 ## distribution.
-deb http://in.archive.ubuntu.com/ubuntu/ xenial-updates main restricted
-# deb-src http://in.archive.ubuntu.com/ubuntu/ xenial-updates main restricted
+deb http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted
 
 ## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
 ## team. Also, please note that software in universe WILL NOT receive any
 ## review or updates from the Ubuntu security team.
-deb http://in.archive.ubuntu.com/ubuntu/ xenial universe
-# deb-src http://in.archive.ubuntu.com/ubuntu/ xenial universe
-deb http://in.archive.ubuntu.com/ubuntu/ xenial-updates universe
-# deb-src http://in.archive.ubuntu.com/ubuntu/ xenial-updates universe
+deb http://archive.ubuntu.com/ubuntu/ xenial universe
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial universe
+deb http://archive.ubuntu.com/ubuntu/ xenial-updates universe
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial-updates universe
 
 ## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
 ## team, and may not be under a free licence. Please satisfy yourself as to
 ## your rights to use the software. Also, please note that software in
 ## multiverse WILL NOT receive any review or updates from the Ubuntu
 ## security team.
-deb http://in.archive.ubuntu.com/ubuntu/ xenial multiverse
-# deb-src http://in.archive.ubuntu.com/ubuntu/ xenial multiverse
-deb http://in.archive.ubuntu.com/ubuntu/ xenial-updates multiverse
-# deb-src http://in.archive.ubuntu.com/ubuntu/ xenial-updates multiverse
+deb http://archive.ubuntu.com/ubuntu/ xenial multiverse
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial multiverse
+deb http://archive.ubuntu.com/ubuntu/ xenial-updates multiverse
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial-updates multiverse
 ## N.B. software from this repository may not have been tested as
 ## extensively as that contained in the main release, although it includes
 ## newer versions of some applications which may provide useful features.
 ## Also, please note that software in backports WILL NOT receive any review
 ## or updates from the Ubuntu security team.
-deb http://in.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
-# deb-src http://in.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
+# deb-src http://archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
 
 ## Uncomment the following two lines to add software from Canonical's
 ## 'partner' repository.


### PR DESCRIPTION
Issue: 72

#### What does this PR do?
Removes India as the default ubuntu archive.

#### Do you have any concerns with this PR?
Yes, need Aricent to weigh in on this one. It may have detrimental impacts there.
I'd recommend they do a "dig archive.ubuntu.com" and note the results.
It should be round robin results of nearby IPs. (Geo local).
In Colorado it returns 
archive.ubuntu.com.	166	IN	A	91.189.88.161
archive.ubuntu.com.	166	IN	A	91.189.88.162
archive.ubuntu.com.	166	IN	A	91.189.88.149
archive.ubuntu.com.	166	IN	A	91.189.88.152


#### How can the reviewer verify this PR?
After box is installed, do an "apt-get update" and make sure that the apt cache updates properly.

#### Any background context you want to provide?
Sending the cablelabs to India for updates is illogical.

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
Yes.

- Does the documentation need an update?
No.

- Does this add new Python dependencies?
No.

- Have you added unit or functional tests for this PR?
No
