### PR TITLE
Add serial console ttyS1

### DIFF
--- a/conf/pxe_cluster/ks.cfg
+++ b/conf/pxe_cluster/ks.cfg
@@ -145,3 +145,8 @@ server 172.16.141.17 iburst
 EOF
 
 %end
+
+%post
+sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX=" console=ttyS1,115200 "/g' /etc/default/grub
+update-grub
+%end

--- a/conf/pxe_cluster/menu.cfg
+++ b/conf/pxe_cluster/menu.cfg
@@ -17,4 +17,4 @@ menu margin 8
 menu title installer boot menu
 label linux
         kernel ubuntu-installer/amd64/linux
-        append ks=http://172.16.141.17/ubuntu/ks.cfg vga=normal initrd=ubuntu-installer/amd64/initrd.gz  url=http://172.16.141.17/ubuntu/preseed/hwe-ubuntu-server.seed live-installer/net-image=http://172.16.141.17/ubuntu/install/filesystem.squashfs ramdisk_size=16432 root=/dev/rd/0 rw  --
+        append ks=http://172.16.141.17/ubuntu/ks.cfg vga=normal initrd=ubuntu-installer/amd64/initrd.gz  url=http://172.16.141.17/ubuntu/preseed/hwe-ubuntu-server.seed live-installer/net-image=http://172.16.141.17/ubuntu/install/filesystem.squashfs console=ttyS1,115200 console=ttyS0,115200 console=tty ramdisk_size=16432 root=/dev/rd/0 rw  --

--- a/scripts/PxeInstall.sh
+++ b/scripts/PxeInstall.sh
@@ -260,7 +260,7 @@ menu margin 8
 menu title installer boot menu
 label linux
         kernel ubuntu-installer/amd64/linux
-        append ks=http://$1/ubuntu/ks.cfg vga=normal initrd=ubuntu-installer/amd64/initrd.gz  url=http://$1/ubuntu/preseed/$2 live-installer/net-image=http://$1/ubuntu/install/filesystem.squashfs ramdisk_size=16432 root=/dev/rd/0 rw  --
+        append ks=http://$1/ubuntu/ks.cfg vga=normal initrd=ubuntu-installer/amd64/initrd.gz  url=http://$1/ubuntu/preseed/$2 live-installer/net-image=http://$1/ubuntu/install/filesystem.squashfs console=ttyS1,115200 console=ttyS0,115200 console=tty ramdisk_size=16432 root=/dev/rd/0 rw  --
 
 EOF
 command_status=$?


### PR DESCRIPTION
Use sed to modify /etc/default/grub to add a serial console
on ttyS1 at 115200 baud. This allows for much better
progress monitoring on snaps-boot builds.

Issue: 66

#### What does this PR do?
Adds a serial console to the kernel command line.

#### Do you have any concerns with this PR?
No.

#### How can the reviewer verify this PR?
Validate that ttyS1 is now getting kernel output and has a getty running.

#### Any background context you want to provide?
systemd by default will run a getty on the first kernel console entry.

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
Yes.

- Does the documentation need an update?
Not really, but maybe mention this in the install.md

- Does this add new Python dependencies?
No.

- Have you added unit or functional tests for this PR?
No.