### PR TITLE
Returned back to pbr, requirements.txt mode of defining project.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pbr
+ansible<2.4,>=2.1.0
+cryptography
+mock
+paramiko
+PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[metadata]
+name = snaps-boot
+version = 1.0
+home-page = https://github.com/cablelabs/snaps-boot
+author = Steve Pisarski
+author-email = s.pisarski@cablelabs.com
+
+[files]
+packages = snaps_boot

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2018 ARICENT HOLDINGS LUXEMBOURG SARL and Cable Television
+# Copyright 2017 ARICENT HOLDINGS LUXEMBOURG SARL and Cable Television
 # Laboratories, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,29 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-__author__ = 'spisarski'
+import setuptools
 
 try:
-    from setuptools import setup, find_packages
+    import multiprocessing  # noqa
 except ImportError:
-    from distutils.core import setup
+    pass
 
-config = {
-    'description': 'Installs OS via IPMI and PXE',
-    'author': 'Steve Pisarski',
-    'url': 'https://github.com/cablelabs/snaps-boot',
-    'download_url': 'https://github.com/cablelabs/snaps-boot.git',
-    'author_email': 's.pisarski@cablelabs.com',
-    'version': '1.0',
-    'packages': find_packages(),
-    'install_requires': ['ansible<2.4,>=2.1.0',
-                         'cryptography',
-                         'mock',
-                         'paramiko',
-                         'PyYAML'],
-    'scripts': [],
-    'name': 'snaps-boot'
-}
-
-setup(**config)
+setuptools.setup(
+    setup_requires=['pbr>=2.0.0'],
+    pbr=True)


### PR DESCRIPTION
This method was actually broken in my development environment due to
SSL certificates. I have also improved this pbr approach to defining
a Python project by adding a setup.cfg file that did not exist the
previous time I attempted this method.

#### What does this PR do?
Improves Python project setup
#### Do you have any concerns with this PR?
Not really except that clients my not have SSL certificates setup for downloading Pypi resources
#### How can the reviewer verify this PR?
Install the project into their own Python runtime
#### Any background context you want to provide?
n/a
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
yes
- Des the documentation need an update?
no
- Does this add new Python dependencies?
pbr
- Have you added unit or functional tests for this PR?
no
