### PR TITLE
Safe file parsing

### DIFF
--- a/ci/playbooks/setup_build.yaml
+++ b/ci/playbooks/setup_build.yaml
@@ -21,14 +21,11 @@
         state: absent
         dest: "{{ src_copy_dir }}/snaps-boot"
 
-    - name: Copy this source tree from local {{ local_snaps_boot_dir }} to {{ src_copy_dir }}/snaps-boot
+    - name: Copy this source tree from local {{ src_snaps_boot_dir }} to {{ src_copy_dir }}/snaps-boot
       synchronize:
-        src: "{{ local_snaps_boot_dir }}"
+        src: "{{ src_snaps_boot_dir }}"
         dest: "{{ src_copy_dir }}"
         dirs: yes
-        rsync_opts:
-          - "--no-motd"
-          - "--exclude=.git"
 
     - name: Install python-pip
       become: yes
@@ -47,8 +44,11 @@
     - name: Download PXE image - ubuntu-16.04.4-server-amd64.iso
       get_url:
         url: http://releases.ubuntu.com/16.04/ubuntu-16.04.4-server-amd64.iso
-        dest: "{{ src_copy_dir }}/snaps-boot/packages/images/ubuntu-16.04.4-server-amd64.iso"
+        dest: "{{ src_copy_dir }}/ubuntu-16.04.4-server-amd64.iso"
         timeout: 1000
+
+    - name: Copy PXE image to - {{ src_copy_dir }}/snaps-boot/packages/images/ubuntu-16.04.4-server-amd64.iso
+      command: "cp {{ src_copy_dir }}/ubuntu-16.04.4-server-amd64.iso {{ src_copy_dir }}/snaps-boot/packages/images/ubuntu-16.04.4-server-amd64.iso"
 
     - name: Apply template and copy hosts.yaml to {{ hosts_yaml_path }}
       action: template src=templates/hosts.yaml.tmplt dest={{ hosts_yaml_path }}

--- a/ci/snaps/snaps_env.yaml.tmplt
+++ b/ci/snaps/snaps_env.yaml.tmplt
@@ -1,0 +1,33 @@
+---
+build_num: {{ build_id }}
+
+# These values are variable
+admin_user: admin
+admin_proj: admin
+admin_pass: {{ os_pass }}
+auth_url: {{ os_auth_url }}
+id_api_version: 3
+proxy_host:
+proxy_port:
+ssh_proxy_cmd:
+
+ext_net: {{ ext_net }}
+ext_subnet: {{ ext_subnet }}
+
+src_copy_dir: /tmp
+local_snaps_boot_dir: {{ path_to_this_repo }}
+
+os_pxe_user_pass: password
+
+ctrl_ip_prfx: 10.0.0
+admin_ip_prfx: 10.1.0
+priv_ip_prfx: 10.1.1
+pub_ip_prfx: 10.1.2
+
+build_kp_pub_path: /tmp/pxe-kp-launcher.pub
+build_kp_priv_path: /tmp/pxe-kp-launcher
+
+pxe_machine_user: root
+pxe_machine_pass: Pa$$w0rd
+
+hosts_yaml_target_path: /tmp/hosts.yaml

--- a/ci/snaps/snaps_pxe_tmplt.yaml
+++ b/ci/snaps/snaps_pxe_tmplt.yaml
@@ -332,7 +332,7 @@ ansible:
     variables:
       src_snaps_boot_dir:
         type: string
-        value: {{ src_snaps_boot_dir }}
+        value: {{ local_snaps_boot_dir }}
       src_copy_dir:
         type: string
         value: {{ src_copy_dir }}

--- a/snaps_boot/common/utils/file_utils.py
+++ b/snaps_boot/common/utils/file_utils.py
@@ -30,7 +30,7 @@ def read_yaml(config_file_path):
     :return: a dictionary
     """
     logger.debug('Loading configuration file - ' + config_file_path)
-    with open(config_file_path) as config_file:
+    with open(config_file_path, 'r') as config_file:
         config = yaml.safe_load(config_file)
         logger.info('Configuration Loaded')
     config_file.close()


### PR DESCRIPTION
#### What does this PR do?
Opens the config file with readonly instead of with the default which I believe is read/write which should be safer should another process already have the file opened
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
run it via ci or baremetal but the change is so trivial at a functional level it should not break anything
#### Any background context you want to provide?
While creating installation scripts to marry this project with snaps-kubernetes, I had to generate config files and have found some issues with opening them as other processes may be still holding some sort of lock.
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
no
- Does the documentation need an update?
no
- Does this add new Python dependencies?
no
- Have you added unit or functional tests for this PR?
I have made a few minor changes to the scripts and added a template for the environment file.
