### PR TITLE
remove jdk installation

### DIFF
--- a/scripts/PreRequisite.sh
+++ b/scripts/PreRequisite.sh
@@ -92,14 +92,6 @@ checkStatus $command_status "ssh-keygen "
 sleep 5
 
 echo "++++++++++++++++++++++++++++++++++++++++++++++"
-echo "apt-get install openjdk"
-echo "++++++++++++++++++++++++++++++++++++++++++++++"
-sudo apt-get install -y openjdk-8-jdk
-command_status=$?
-checkStatus $command_status "install  openjdk using apt-get"
-sleep 5
-
-echo "++++++++++++++++++++++++++++++++++++++++++++++"
 echo "pip install cryptography"
 echo "++++++++++++++++++++++++++++++++++++++++++++++"
 sudo pip install cryptography


### PR DESCRIPTION
#### What does this PR do?
removes jdk installation from PreRequisites.sh
#### Do you have any concerns with this PR?
Only if JDK is necessary for baremetal but it does not appear so. The only component that possibly require java would be IPMI which is not being exercised with the OpenStack ci smoke tests
#### How can the reviewer verify this PR?
execute on baremetal. Runs fine on OpenStack
#### Any background context you want to provide?
jdk takes a long time to install and should be removed if no longer necessary
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
yes
- Does the documentation need an update?
no
- Does this add new Python dependencies?
no
- Have you added unit or functional tests for this PR?
no, existing ones should be fine
