### PR TITLE
Cleaned up the prerequisites

### DIFF
--- a/ci/playbooks/setup_build.yaml
+++ b/ci/playbooks/setup_build.yaml
@@ -35,6 +35,9 @@
 
     - name: Install snaps-boot
       command: pip install -e {{ src_copy_dir }}/snaps-boot
+      become: yes
+      become_method: sudo
+      become_user: root
 
     - name: Make directory {{ src_copy_dir }}/snaps-boot/packages/images
       file:

--- a/scripts/PreRequisite.sh
+++ b/scripts/PreRequisite.sh
@@ -31,22 +31,6 @@ command_status=$?
 checkStatus $command_status "install apt-cache-eng  using apt-get"
 sleep 5
 
-echo "++++++++++++++++++++++++++++++++++++++++++++++"
-echo "apt-get install python-yaml "
-echo "++++++++++++++++++++++++++++++++++++++++++++++"
-apt-get install python-yaml
-command_status=$?
-checkStatus $command_status "install  yaml  using apt-get"
-sleep 5
-
-echo "++++++++++++++++++++++++++++++++++++++++++++++"
-echo "apt-get install ansible "
-echo "++++++++++++++++++++++++++++++++++++++++++++++"
-apt-get install -y ansible
-command_status=$?
-checkStatus $command_status "install  ansible  using apt-get"
-sleep 5
-
 
 echo "++++++++++++++++++++++++++++++++++++++++++++++"
 echo "apt-get install ipmitool"
@@ -65,19 +49,3 @@ checkStatus $command_status "install sshpass  using apt-get"
 sleep 5
 
 
-echo "++++++++++++++++++++++++++++++++++++++++++++++"
-echo "ssh-keygen   generation "
-echo "++++++++++++++++++++++++++++++++++++++++++++++"
-#ssh-keygen -t rsa -N "" -f ssh.key
-#ssh-copy-id -i ssh.key.pub YOUR-REMOTE-HOST-IP
-command_status=$?
-checkStatus $command_status "ssh-keygen "
-sleep 5
-
-echo "++++++++++++++++++++++++++++++++++++++++++++++"
-echo "pip install cryptography"
-echo "++++++++++++++++++++++++++++++++++++++++++++++"
-sudo pip install cryptography
-command_status=$?
-checkStatus $command_status "install cryptography using pip"
-sleep 5


### PR DESCRIPTION
#### What does this PR do?

- Installation through requirements.txt rather than prerequisites.sh
- Package installs for apt-cacher-ng, ipmitool and sshpass have to be moved to the playbooks that require them.

#### Do you have any concerns with this PR?
#### How can the reviewer verify this PR?
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
- Does the documentation need an update?
- Does this add new Python dependencies?
- Have you added unit or functional tests for this PR?