### PR TITLE
Removed netcfg from ks.cfg file. This should fix the DHCP hang in BIO…

### DIFF
--- a/conf/pxe_cluster/ks.cfg
+++ b/conf/pxe_cluster/ks.cfg
@@ -50,8 +50,6 @@ preseed partman/confirm boolean true
 preseed partman/confirm_nooverwrite boolean true
 preseed --owner partman-basicfilesystems partman-basicfilesystems/no_swap boolean false.
 
-network --bootproto=dhcp --device=en0
-
 reboot
 
 


### PR DESCRIPTION
…S installs.

#### What does this PR do?
Removes network option in the ks.cfg file so the installer picks the best interface to do DHCP from
#### Do you have any concerns with this PR?
No
#### How can the reviewer verify this PR?
Run a snaps-boot install on a BIOS system and make sure it installs hands free
#### Any background context you want to provide?
This was caused by the UEFI fix #90.  Since UEFI sets the interfaces.  
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
yes
- Does the documentation need an update?
No
- Does this add new Python dependencies?
No
- Have you added unit or functional tests for this PR?
No
- Does this patch update any configuration files?
Yes, ks.cfg removed a line for network --boot=dhcp interface=en0
