### PR TITLE
Snaps interface

### DIFF
--- a/ci/playbooks/setup_build.yaml
+++ b/ci/playbooks/setup_build.yaml
@@ -16,15 +16,10 @@
 - hosts: all
 
   tasks:
-    - name: Delete {{ src_copy_dir }}/snaps-boot directory
-      file:
-        state: absent
-        dest: "{{ src_copy_dir }}/snaps-boot"
-
-    - name: Copy this source tree from local {{ src_snaps_boot_dir }} to {{ src_copy_dir }}/snaps-boot
+    - name: Copy this source tree to {{ src_copy_dir }}/snaps-boot
       synchronize:
-        src: "{{ src_snaps_boot_dir }}"
-        dest: "{{ src_copy_dir }}"
+        src: ../../../
+        dest: "{{ src_copy_dir }}/snaps-boot"
         dirs: yes
 
     - name: Install python-pip
@@ -58,14 +53,6 @@
       become_method: sudo
       become_user: root
       command: "sh {{ src_copy_dir }}/snaps-boot/scripts/PreRequisite.sh"
-      register: out
-    - debug: var=out.stderr_lines
-
-    - name: Clean just in case PXE & DHCP server - iaas_launch.py -pc
-      become: yes
-      become_method: sudo
-      become_user: root
-      command: "python {{ src_copy_dir }}/snaps-boot/iaas_launch.py -f {{ hosts_yaml_path }} -pc"
       register: out
     - debug: var=out.stderr_lines
 

--- a/ci/snaps/snaps_pxe_env.yaml
+++ b/ci/snaps/snaps_pxe_env.yaml
@@ -13,9 +13,8 @@ ssh_proxy_cmd:
 ext_net: {{ external_network_name }}
 ext_subnet: {{ external_subnet_name }}
 
-src_snaps_boot_dir: {{ src_snaps_boot_dir }}
 src_copy_dir: /tmp
-local_snaps_boot_dir: /tmp/snaps-boot
+local_snaps_boot_dir: {{ local_snaps_boot_dir }}
 
 os_pxe_user_pass: password
 

--- a/ci/snaps/snaps_pxe_tmplt.yaml
+++ b/ci/snaps/snaps_pxe_tmplt.yaml
@@ -260,7 +260,6 @@ openstack:
         name: pxe-vm-1-{{ build_num }}
         flavor: pxe-flavor-{{ build_num }}
         imageName: pxe-image-{{ build_num }}
-#        security_group_names: [pxe-vm-sg-{{ build_num }}]
         ports:
           - port:
               name: pxe-admin-port-1-{{ build_num }}
@@ -290,7 +289,6 @@ openstack:
         name: pxe-vm-2-{{ build_num }}
         flavor: pxe-flavor-{{ build_num }}
         imageName: pxe-image-{{ build_num }}
-#        security_group_names: [pxe-vm-sg-{{ build_num }}]
         ports:
           - port:
               name: pxe-admin-port-2-{{ build_num }}
@@ -320,7 +318,6 @@ openstack:
         name: pxe-vm-3-{{ build_num }}
         flavor: pxe-flavor-{{ build_num }}
         imageName: pxe-image-{{ build_num }}
-#        security_group_names: [pxe-vm-sg-{{ build_num }}]
         ports:
           - port:
               name: pxe-admin-port-3-{{ build_num }}
@@ -361,15 +358,9 @@ ansible:
       pxe_config:
         type: string
         value: {{ install_type }}
-      src_snaps_boot_dir:
-        type: string
-        value: {{ local_snaps_boot_dir }}
       src_copy_dir:
         type: string
         value: {{ src_copy_dir }}
-      local_snaps_boot_dir:
-        type: string
-        value: {{ local_snaps_boot_dir }}
       priv_addr:
         type: network
         network_name: admin-net-{{ build_num }}

--- a/doc/source/install/install.md
+++ b/doc/source/install/install.md
@@ -470,7 +470,7 @@ ip aserver boot times.
 This will also set the static ip for the target hosts.
 
 >:warning: This step will reboot each target server when it is done.  
-Wait a few minutes then ping and/or ssh each management server to verify  
+Wait a few minutes then ping and/or ssh each target server to verify  
 it is back up. 
 
 #### Step 7 (optional)
@@ -487,7 +487,7 @@ Run `iaas_launch.py` as shown below:
 sudo -i python $PWD/iaas_launch.py -f $PWD/conf/pxe_cluster/hosts.yaml -s
 ```
 >:warning: This step will reboot each target server when it is done.  
-Wait a few minutes then ping and/or ssh each management server to verify  
+Wait a few minutes then ping and/or ssh each target server to verify  
 it is back up. 
 
 > Note: This is an optional step and the same functionality is also present in

--- a/doc/source/install/install.md
+++ b/doc/source/install/install.md
@@ -469,7 +469,15 @@ ip aserver boot times.
 
 This will also set the static ip for the target hosts.
 
+>:warning: This step will reboot each target server when it is done.  
+Wait a few minutes then ping and/or ssh each management server to verify  
+it is back up. 
+
 #### Step 7 (optional)
+
+The -s option can be maintained as a troubleshooting tool for static ip 
+configuration 
+
 Go to root directory of the project (e.g. `snaps-boot`)
 
 Execute this step only if static IPs to be assigned to host machines.
@@ -481,6 +489,9 @@ sudo -i python $PWD/iaas_launch.py -f $PWD/conf/pxe_cluster/hosts.yaml -s
 >:warning: This step will reboot each target server when it is done.  
 Wait a few minutes then ping and/or ssh each management server to verify  
 it is back up. 
+
+> Note: This is an optional step and the same functionality is also present in
+-b option (static ip of target host are set after pxe boot )
 
 #### Step 8
 Go to root directory of the project (e.g. `snaps-boot`)
@@ -514,7 +525,9 @@ Back to Management Interface
 sudo -i python $PWD/iaas_launch.py -f $PWD/conf/pxe_cluster/hosts.yaml -sc
 ```
 
-This will modify etc/network/interfaces file to remove static entries of the interfaces and will change back default route to management interface.
+This will remove the static config files present in  etc/network/interfaces.d/ folder.
+this will remove static entries of the interfaces and will change back default route to 
+management interface after reboot.
 
 ### 5.3 Roll-back of SNAPS-Boot Installation
 

--- a/doc/source/install/install.md
+++ b/doc/source/install/install.md
@@ -467,7 +467,9 @@ Your OS provisioning will start and will get completed in about 20
 minutes.  The time will vary depending on your network speed and
 ip aserver boot times.
 
-#### Step 7
+This will also set the static ip for the target hosts.
+
+#### Step 7 (optional)
 Go to root directory of the project (e.g. `snaps-boot`)
 
 Execute this step only if static IPs to be assigned to host machines.

--- a/snaps_boot/ansible_p/commission/hardware/playbooks/delIPConfig.yaml
+++ b/snaps_boot/ansible_p/commission/hardware/playbooks/delIPConfig.yaml
@@ -24,14 +24,11 @@
      command: mv /etc/resolvconf/resolv.conf.d/base.bak /etc/resolvconf/resolv.conf.d/base
      ignore_errors: True
      when: is_ext|bool and true
-   - name: Deleting connection address
-     command: ifconfig "{{ iface }}" 0.0.0.0
-     ignore_errors: True
-     when: is_ext|bool and true
-   - name: ifconfig down
-     command: ifconfig "{{ iface }}" down
-     ignore_errors: True
-     when: is_ext|bool and true
+   - name: remove the interfaces file
+     file:
+       state: absent
+       path: /etc/network/interfaces.d/static.cfg
+
    - name: restarting system
      shell: /sbin/shutdown -r 1 "Ansible restart"
      ignore_errors: True

--- a/snaps_boot/ansible_p/commission/hardware/playbooks/setIPConfig.yaml
+++ b/snaps_boot/ansible_p/commission/hardware/playbooks/setIPConfig.yaml
@@ -31,14 +31,22 @@
           regexp: 'iface {{ iface }} inet dhcp'
           line: "iface {{ iface}} inet static\naddress {{ address }} \nnetmask {{netmask}}"
      when: is_mng|bool and true
+
+   - stat: path=/etc/network/interfaces.d/static.cfg
+     register: out
+
+   - name: create new interfaces file for static.cfg
+     file: path=/etc/network/interfaces.d/static.cfg state=touch
+     when: out.stat.exists is defined and not out.stat.exists
+
    - name: Configuring nodes with static ip for external network
      lineinfile:
-          dest: /etc/network/interfaces
+          dest: /etc/network/interfaces.d/static.cfg
           line: "auto {{ iface }}\niface {{ iface}} inet static\naddress {{ address }} \nnetmask {{ netmask }} \ngateway {{ gateway }}\ndns-nameservers {{ dns }}\ndns-search {{ dn }}\nup route add netmask {{ netmask }} gw {{ gateway }}"
      when: is_ext|bool and true
    - name: Configuring nodes with static ip for tenant network
      lineinfile:
-          dest: /etc/network/interfaces
+          dest: /etc/network/interfaces.d/static.cfg
           line: "auto {{ iface }}\niface {{ iface }} inet static\naddress {{ address }} \nnetmask {{ netmask }}"
      when: is_tnt|bool and true
    - name: Backing up resolv.conf

--- a/snaps_boot/ansible_p/commission/hardware/playbooks/setIPConfig.yaml
+++ b/snaps_boot/ansible_p/commission/hardware/playbooks/setIPConfig.yaml
@@ -23,7 +23,7 @@
     http_proxy: "{{ http_proxy }}"
     https_proxy: "{{ https_proxy }}"
   tasks:
-   - name: Configuring nodes with static ip for mangment network
+   - name: Configuring nodes with static ip for management network
      lineinfile:
           dest: /etc/network/interfaces
           state: present

--- a/snaps_boot/ansible_p/commission/hardware/playbooks/waitServer.yaml
+++ b/snaps_boot/ansible_p/commission/hardware/playbooks/waitServer.yaml
@@ -1,0 +1,12 @@
+---
+- hosts: localhost
+  tasks:
+    - name: Wait for reboot 
+      wait_for:
+         host: "{{ target }}"
+         port: 22 
+         timeout: 1700 
+         delay: 10 
+         state: started
+    - name: remove known hosts entry
+      shell: 'ssh-keygen -f "/root/.ssh/known_hosts" -R {{target}}'

--- a/snaps_boot/provision/hardware/pxe_utils.py
+++ b/snaps_boot/provision/hardware/pxe_utils.py
@@ -739,6 +739,32 @@ def __static_ip_configure(static_dict, proxy_dict):
     https_proxy = proxy_dict.get('https_proxy')
     iplist = []
 
+    next_word = None
+    with open("conf/pxe_cluster/ks.cfg") as openfile:
+        for line in openfile:
+            list_word = line.split()
+            for part in line.split():
+                if "rootpw" in part:
+                    next_word = list_word[list_word.index("rootpw") + 1]
+
+    user_name = 'root'
+    password = next_word
+    check_dir = os.path.isdir(consts.SSH_PATH)
+    if not check_dir:
+        os.makedirs(consts.SSH_PATH)
+    for i in range(len(host)):
+        target = host[i].get('access_ip')
+        iplist.append(target)
+    for i in range(len(host)):
+        target = host[i].get('access_ip')
+        command= 'ansible-playbook %s --extra-vars "target=%s"' % (playbook_path_waitServer, target)
+        subprocess.call(command, shell=True)
+        __create_and_save_keys()
+
+        command = 'sshpass -p \'%s\' ssh-copy-id -o ' \
+                  'StrictHostKeyChecking=no %s@%s' \
+                  % (password, user_name, target)
+                     
     for this_host in host:
         target = this_host.get('access_ip')
         iplist.append(target)

--- a/snaps_boot/provision/hardware/pxe_utils.py
+++ b/snaps_boot/provision/hardware/pxe_utils.py
@@ -739,32 +739,11 @@ def __static_ip_configure(static_dict, proxy_dict):
     https_proxy = proxy_dict.get('https_proxy')
     iplist = []
 
-    next_word = None
-    with open("conf/pxe_cluster/ks.cfg") as openfile:
-        for line in openfile:
-            list_word = line.split()
-            for part in line.split():
-                if "rootpw" in part:
-                    next_word = list_word[list_word.index("rootpw") + 1]
-
-    user_name = 'root'
-    password = next_word
-    check_dir = os.path.isdir(consts.SSH_PATH)
-    if not check_dir:
-        os.makedirs(consts.SSH_PATH)
-    for i in range(len(host)):
-        target = host[i].get('access_ip')
-        iplist.append(target)
-    for i in range(len(host)):
-        target = host[i].get('access_ip')
+    for this_host in host:
+        target = this_host.get('access_ip')
         command= 'ansible-playbook %s --extra-vars "target=%s"' % (playbook_path_waitServer, target)
         subprocess.call(command, shell=True)
-        __create_and_save_keys()
-
-        command = 'sshpass -p \'%s\' ssh-copy-id -o ' \
-                  'StrictHostKeyChecking=no %s@%s' \
-                  % (password, user_name, target)
-                     
+        
     for this_host in host:
         target = this_host.get('access_ip')
         iplist.append(target)

--- a/snaps_boot/provision/hardware/pxe_utils.py
+++ b/snaps_boot/provision/hardware/pxe_utils.py
@@ -1,5 +1,5 @@
 
-import subprocess# Copyright 2017 ARICENT HOLDINGS LUXEMBOURG SARL and Cable Television
+# Copyright 2017 ARICENT HOLDINGS LUXEMBOURG SARL and Cable Television
 # Laboratories, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/snaps_boot/provision/hardware/pxe_utils.py
+++ b/snaps_boot/provision/hardware/pxe_utils.py
@@ -1,4 +1,5 @@
-# Copyright 2017 ARICENT HOLDINGS LUXEMBOURG SARL and Cable Television
+
+import subprocess# Copyright 2017 ARICENT HOLDINGS LUXEMBOURG SARL and Cable Television
 # Laboratories, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +24,7 @@ import re
 
 import os
 import pkg_resources
+import subprocess
 
 from snaps_boot.ansible_p.ansible_utils import ansible_playbook_launcher as apl
 


### PR DESCRIPTION
#### What does this PR do?
This PR removes the requirement of performing -s after the -b option in snaps-boot
Also this PR creates separate interface file for the static cfg in /etc/network/interfaces.d/ folder
#### Do you have any concerns with this PR?
No
#### How can the reviewer verify this PR?
By deploying the -b option and validating if the static ip is also reflected
#### Any background context you want to provide?
NA
#### Screenshots or logs (if appropriate)
NA
#### Questions:
- Have you connected this PR to the issue it resolves?
PR #121 
- Does the documentation need an update?
Yes
- Does this add new Python dependencies?
No
- Have you added unit or functional tests for this PR?
No
- Does this patch update any configuration files?
No