### PR TITLE
Issue 122

### DIFF
--- a/conf/pxe_cluster/grub.cfg
+++ b/conf/pxe_cluster/grub.cfg
@@ -19,6 +19,6 @@
 
 menuentry "Install Ubuntu" {
 set gfxpayload=keep
-linux ubuntu-installer/amd64/linux gfxpayload=800x600x16,800x600 hostname=Mangament netcfg/choose_interface=en0 live-installer/net-image=http://192.168.0.1/ubuntu/install/filesystem.squashfs --- auto=true url=http://192.168.0.1/ubuntu/preseed/hwe-ubuntu-server-uefi.seed ks=http://192.168.0.1/ubuntu/ks.cfg
+linux ubuntu-installer/amd64/linux gfxpayload=800x600x16,800x600 netcfg/choose_interface=en0  hostname=compute live-installer/net-image=http://192.168.0.1/ubuntu/install/filesystem.squashfs --- auto=true url=http://192.168.0.1/ubuntu/preseed/hwe-ubuntu-server-uefi.seed ks=http://192.168.0.1/ubuntu/ks.cfg
 initrd ubuntu-installer/amd64/initrd.gz
 }

--- a/conf/pxe_cluster/post.sh
+++ b/conf/pxe_cluster/post.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+cat > /etc/apt/sources.list <<EOF
+deb http://archive.ubuntu.com/ubuntu/ xenial main restricted
+deb http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted
+deb http://archive.ubuntu.com/ubuntu/ xenial universe
+deb http://archive.ubuntu.com/ubuntu/ xenial-updates universe
+deb http://archive.ubuntu.com/ubuntu/ xenial multiverse
+deb http://archive.ubuntu.com/ubuntu/ xenial-updates multiverse
+deb http://archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
+deb http://security.ubuntu.com/ubuntu xenial-security main restricted
+deb http://security.ubuntu.com/ubuntu xenial-security universe
+deb http://security.ubuntu.com/ubuntu xenial-security multiverse
+EOF
+
+
+
+
+apt-get -f -y install
+apt-get -qq -y autoremove
+apt-get clean
+apt-get -qq -y update
+apt-get -qq -y install python
+apt-get -qq -y install cloud-init
+apt-get -qq -y install libltdl7
+sed -i 's/prohibit-password/yes/' /etc/ssh/sshd_config
+service ssh restart
+
+apt-get -y install ntp
+cat >> /etc/ntp.conf <<EOF
+server 172.16.141.17 iburst
+EOF
+
+
+#Get the MAC for the first working NIC
+ADMIN_MAC=$(ip a | grep -v lo| awk 'f{print $2;f=0;exit} /UP/{f=1}')
+CLOUD_INIT_IP=10.197.143.11
+sed -E -i "s/GRUB_CMDLINE_LINUX=\"\"/GRUB_CMDLINE_LINUX=\" console=ttyS1,115200  ds=nocloud-net cloud-config-url=http:\/\/$CLOUD_INIT_IP\/latest\/meta-data\/$ADMIN_MAC \"/g" /etc/default/grub
+update-grub
+cat >> /etc/modprobe.d/nest.conf <<EOF
+options kvm_intel nested=1
+EOF

--- a/conf/pxe_cluster/post.sh
+++ b/conf/pxe_cluster/post.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+cat > /etc/apt/apt.conf <<EOF
+Acquire::http::Proxy "http://172.16.141.17:3142";
+Acquire::http::Proxy "http://172.16.141.17:3142";
+Acquire::ftp::Proxy "";
+EOF
+
 cat > /etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ xenial main restricted
 deb http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted
@@ -33,7 +40,7 @@ EOF
 
 #Get the MAC for the first working NIC
 ADMIN_MAC=$(ip a | grep -v lo| awk 'f{print $2;f=0;exit} /UP/{f=1}')
-CLOUD_INIT_IP=10.197.143.11
+CLOUD_INIT_IP=cloud-init-ip
 sed -E -i "s/GRUB_CMDLINE_LINUX=\"\"/GRUB_CMDLINE_LINUX=\" console=ttyS1,115200  ds=nocloud-net cloud-config-url=http:\/\/$CLOUD_INIT_IP\/latest\/meta-data\/$ADMIN_MAC \"/g" /etc/default/grub
 update-grub
 cat >> /etc/modprobe.d/nest.conf <<EOF

--- a/conf/pxe_cluster/ubuntu-uefi-server.seed
+++ b/conf/pxe_cluster/ubuntu-uefi-server.seed
@@ -1,93 +1,142 @@
 d-i 	debconf/priority string critical
-#d-i 	partman-auto/disk string /dev/sda
-
-# The presently available methods are:
-# - regular: use the usual partition types for your architecture
-# - lvm:     use LVM to partition the disk
-# - crypto:  use LVM within an encrypted partition
-d-i     partman-auto/method string lvm
-d-i     partman-auto/choose_recipe select atomic
-
-# If one of the disks that are going to be automatically partitioned
-# contains an old LVM configuration, the user will normally receive a
-# warning. This can be preseeded away...
-d-i 	partman-lvm/device_remove_lvm boolean true
-
-# The same applies to pre-existing software RAID array:
-d-i 	partman-md/device_remove_md boolean true
-
-# And the same goes for the confirmation to write the lvm partitions.
-d-i 	partman-lvm/confirm boolean true
-d-i 	partman-lvm/confirm_nooverwrite boolean true
-
-# This makes partman automatically partition without confirmation, provided
-# that you told it what to do using one of the methods above.
-d-i 	partman-partitioning/confirm_write_new_label boolean true
-d-i 	partman/choose_partition select finish
-d-i 	partman/confirm boolean true
-d-i 	partman/confirm_nooverwrite boolean true
-
-#If there is a non-efi os on the system, install anyway
-d-i 	partman-efi/non_efi_system boolean true
-
-# Equivalent to url --url=http://<> in ks.cfg
-d-i 	mirror/country string manual
-d-i 	mirror/http/hostname string 192.168.0.1
-d-i 	mirror/http/directory string /ubuntu
-d-i 	mirror/http/proxy string
-
-# Select correct ethernet intefce
-d-i     netcfg/choose_interface select en0
-d-i     netcfg/dhcp_timeout string 240
-
-# User Accounts
-d-i 	debian-installer/locale string en_US
-d-i 	passwd/root-login boolean true
-d-i 	passwd/root-password password fake
-d-i 	passwd/root-password-again password fake
 
 #Localization
-d-i     debian-installer/locale string en_US.UTF-8
+d-i debian-installer/locale string en_US.UTF-8
 
 #Keyboard selection
 d-i console-setup/ask_detect boolean false
 d-i keyboard-configuration/layoutcode string us
 
+# Select correct ethernet interface
+d-i netcfg/choose_interface select en0
+d-i netcfg/dhcp_timeout string 240
+
 # Set hostname
-d-i netcfg/get_hostname string ubuntu
+#d-i netcfg/get_hostname string ubuntu
+#d-i netcfg/get_domain string cablelabs.com
+d-i netcfg/hostname string compute
+d-i netcfg/wireless_wep string
+d-i netcfg/hostname seen true
+ 
+d-i base-installer/kernel/overrride-image string linux-server
 
-# Create new user
-d-i 	passwd/user-fullname string Ubuntu User
-d-i 	passwd/username string ubuntu
-d-i 	passwd/user-password password fake
-d-i 	passwd/user-password-again password fake
-
-# Don't encrypt the home directory
-d-i     user-setup/encrypt-home boolean false
-
-
-# Install the Ubuntu Server seed.
-tasksel	tasksel/force-tasks	string server
-
-# Only install basic language packs. Let tasksel ask about tasks.
-d-i 	pkgsel/language-pack-patterns	string
-
-# No language support packages.
-d-i 	pkgsel/install-language-support	boolean false
+# Equivalent to url --url=http://<> in ks.cfg
+d-i mirror/country string manual
+d-i mirror/http/hostname string 192.168.0.1
+d-i mirror/http/directory string /ubuntu
+d-i mirror/http/proxy string
 
 # Only ask the UTC question if there are other operating systems installed.
-d-i 	clock-setup/utc-auto	boolean true
+d-i clock-setup/utc-auto boolean true
+d-i time/zone string America/Denver
+d-i clock-setup/ntp boolean true
+d-i clock-setup/ntp-server string 192.168.0.1 
+
+
+### Partitioning
+d-i partman-auto/disk string /dev/sda
+
+# The presently available methods are:
+# - regular: use the usual partition types for your architecture
+# - lvm:     use LVM to partition the disk
+# - crypto:  use LVM within an encrypted partition
+d-i partman-auto/method string lvm 
+
+# If one of the disks that are going to be automatically partitioned
+# contains an old LVM configuration, the user will normally receive a
+# warning. This can be preseeded away...
+d-i partman-lvm/device_remove_lvm boolean true
+# The same applies to pre-existing software RAID array:
+d-i partman-md/device_remove_md boolean true
+# And the same goes for the confirmation to write the lvm partitions.
+# For LVM partitioning, you can select how much of the volume group to use
+# for logical volumes.
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto-lvm/new_vg_name string snaps_vg
+
+# You can choose one of the three predefined partitioning recipes:
+# - atomic: all files in one partition
+# - home:   separate /home partition
+# - multi:  separate /home, /usr, /var, and /tmp partitions
+d-i partman-auto/choose_recipe select atomic
+
+# If you just want to change the default filesystem from ext3 to something
+# else, you can do that without providing a full recipe.
+d-i partman/default_filesystem string ext4
+
+# This makes partman automatically partition without confirmation, provided
+# that you told it what to do using one of the methods above.
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-efi/non_efi_system boolean true
+
+
+# User Accounts
+d-i debian-installer/locale string en_US
+d-i passwd/root-login boolean true
+d-i passwd/root-password password ChangeMe123
+d-i passwd/root-password-again password ChangeMe123
+
+
+
+# Create new user
+d-i passwd/user-fullname string User
+d-i passwd/username string ubuntu
+d-i passwd/user-password password ChangeMe123
+d-i passwd/user-password-again password ChangeMe123
+
+# Don't encrypt the home directory
+d-i user-setup/encrypt-home boolean false
+
 
 # Verbose output and no boot splash screen.
-d-i 	debian-installer/quiet	boolean false
-d-i 	debian-installer/splash	boolean false
-
-# Install the debconf oem-config frontend (if in OEM mode).
-d-i 	oem-config-udeb/frontend	string debconf
+d-i debian-installer/quiet boolean false
+d-i debian-installer/splash boolean false
 
 # Wait for two seconds in grub
-d-i 	grub-installer/timeout	string 2
+d-i grub-installer/timeout string 10
 
-# Add the network and tasks oem-config steps by default.
-oem-config	oem-config/steps	multiselect language, timezone, keyboard, user, network, tasks
-d-i     base-installer/kernel/altmeta   string hwe-16.04
+# Select which update services to use; define the mirrors to be used.
+# Values shown below are the normal defaults.
+d-i pkgsel/update-policy select unattended-upgrades
+d-i apt-setup/services-select multiselect security
+d-i apt-setup/security_host string security.ubuntu.com
+d-i apt-setup/security_path string /ubuntu
+d-i apt-setup/multiverse boolean true
+d-i apt-setup/restricted boolean true
+d-i apt-setup/universe boolean true
+
+### Package selection
+#tasksel tasksel/first multiselect ubuntu-server
+tasksel	tasksel/force-tasks	string server
+
+
+# Individual additional packages to install
+d-i pkgsel/include string openssh-server build-essential curl wget ntp libltdl7
+#d-i pkgsel/language-packs multiselect en
+d-i 	pkgsel/language-pack-patterns	string
+d-i 	pkgsel/install-language-support	boolean false
+
+### Boot loader installation
+# This is fairly safe to set, it makes grub install automatically to the MBR
+# if no other operating system is detected on the machine.
+d-i grub-installer/only_debian boolean true
+
+# This one makes grub-installer install to the MBR if it also finds some other
+# OS, which is less safe as it might not be able to boot that other OS.
+d-i grub-installer/with_other_os boolean true
+
+# Wait for two seconds in grub
+d-i	grub-installer/timeout string 2 
+
+d-i finish-install/reboot_in_progress note
+
+
+
+#POST proessing
+d-i preseed/late_command string wget -O- \
+    http://192.168.0.1/ubuntu/post.sh | \
+    chroot /target /bin/sh -s

--- a/scripts/PxeInstall.sh
+++ b/scripts/PxeInstall.sh
@@ -208,6 +208,7 @@ if [ -f packages/images/"$1" ] #if [ "$1" ] #
 then
     echo "Grub file $1 exists."
 	echo "$pxeServerPass" | sudo -S  cp -fr packages/images/$1 /var/lib/tftpboot
+
 else
     echo "Error: Grub file $1  does not exists."
 	exit 0
@@ -324,6 +325,15 @@ checkStatus $command_status " creation of grub file "
 cp $temp_dir/grub.cfg  /var/lib/tftpboot/grub/grub.cfg
 command_status=$?
 checkStatus $command_status " writing data of local grub  to  /var/lib/tftpboot/grub/grub.cfg"
+
+cp $temp_dir/post.sh  /var/www/html/ubuntu/post.sh
+command_status=$?
+checkStatus $command_status " writing data of local post script  to  /var/www/html/ubuntu/post.sh"
+
+#cp $temp_dir/$2  /var/www/html/ubuntu/preseed/$2
+#command_status=$?
+#checkStatus $command_status " writing data of seed file to  /var/www/html/ubuntu/preseed/" + $2
+
 }
 
 bootMenuConfigure () {

--- a/scripts/PxeInstall.sh
+++ b/scripts/PxeInstall.sh
@@ -313,7 +313,7 @@ set timeout=10
 
 menuentry "Install Ubuntu 16" {
 set gfxpayload=keep
-linux ubuntu-installer/amd64/linux gfxpayload=800x600x16,800x600 netcfg/choose_interface=$4 live-installer/net-image=http://$1/ubuntu/install/filesystem.squashfs --- auto=true url=http://$1/ubuntu/preseed/$2 ks=http://$1/ubuntu/ks.cfg
+linux ubuntu-installer/amd64/linux gfxpayload=800x600x16,800x600 netcfg/choose_interface=$4 hostname=compute live-installer/net-image=http://$1/ubuntu/install/filesystem.squashfs --- auto=true url=http://$1/ubuntu/preseed/$2 ks=http://$1/ubuntu/ks.cfg
 initrd ubuntu-installer/amd64/initrd.gz
 }
 EOF

--- a/snaps_boot/provision/hardware/pxe_utils.py
+++ b/snaps_boot/provision/hardware/pxe_utils.py
@@ -316,58 +316,71 @@ def __create_seed_config(pxe_dict, ubuntu_dict, boot_interface):
     os.system('dos2unix conf/pxe_cluster/ubuntu-uefi-server.seed')
 
     logger.debug("configuring server url  in ubuntu-uefi-server.seed")
-    my_url = "d-i 	mirror/http/hostname string " + pxe_dict["serverIp"]
+    my_url = "d-i mirror/http/hostname string " + pxe_dict["serverIp"]
     __find_and_replace('conf/pxe_cluster/ubuntu-uefi-server.seed',
-                       "d-i 	mirror/http/hostname string 192.168.0.1",
+                       "d-i mirror/http/hostname string 192.168.0.1",
                        my_url)
 
     logger.debug("configuring boot interface in ubuntu-uefi-server.seed")
-    boot_iface = "d-i   netcfg/choose_interface select " + boot_interface
+    boot_iface = "d-i netcfg/choose_interface select " + boot_interface
     __find_and_replace('conf/pxe_cluster/ubuntu-uefi-server.seed',
-                       "d-i     netcfg/choose_interface select en0",
+                       "d-i netcfg/choose_interface select en0",
                        boot_iface)
 
-    logger.debug("configuring client user fullname in ubuntu-uefi-server.seed")
-    user_creds = "d-i   passwd/user-fullname string " + ubuntu_dict["fullname"]
+    logger.debug("configuring ntp in ubuntu-uefi-server.seed")
+    ntp_server = "d-i clock-setup/ntp-server string " + pxe_dict["serverIp"]
     __find_and_replace('conf/pxe_cluster/ubuntu-uefi-server.seed',
-                       "d-i 	passwd/user-fullname string Ubuntu User",
+                       "d-i clock-setup/ntp-server string 192.168.0.1",
+                       ntp_server)
+
+    logger.debug("configuring client user fullname in ubuntu-uefi-server.seed")
+    user_creds = "d-i passwd/user-fullname string " + ubuntu_dict["fullname"]
+    __find_and_replace('conf/pxe_cluster/ubuntu-uefi-server.seed',
+                       "d-i passwd/user-fullname string Ubuntu User",
                        user_creds)
 
     logger.debug("configuring client username in ubuntu-uefi-server.seed")
-    user_creds = "d-i   passwd/username string " + ubuntu_dict["user"]
+    user_creds = "d-i passwd/username string " + ubuntu_dict["user"]
     __find_and_replace('conf/pxe_cluster/ubuntu-uefi-server.seed',
-                       "d-i 	passwd/username string ubuntu", user_creds)
+                       "d-i passwd/username string ubuntu", user_creds)
 
     logger.debug("configuring client user password in ubuntu-uefi-server.seed")
-    user_creds = "d-i 	passwd/user-password password "\
+    user_creds = "d-i passwd/user-password password "\
                  + ubuntu_dict["password"]
     __find_and_replace('conf/pxe_cluster/ubuntu-uefi-server.seed',
-                       "d-i 	passwd/user-password password fake",
+                       "d-i passwd/user-password password ChangeMe123",
                        user_creds)
 
     logger.debug("configuring client user password verify in "
                  "ubuntu-uefi-server.seed")
-    user_creds = "d-i 	passwd/user-password-again password "\
+    user_creds = "d-i passwd/user-password-again password "\
                  + ubuntu_dict["password"]
     __find_and_replace('conf/pxe_cluster/ubuntu-uefi-server.seed',
-                       "d-i 	passwd/user-password-again password fake",
+                       "d-i passwd/user-password-again password ChangeMe123",
                        user_creds)
 
     logger.debug("configuring client root password in "
                  "ubuntu-uefi-server.seed")
-    user_creds = "d-i 	passwd/root-password password "\
+    user_creds = "d-i passwd/root-password password "\
                  + ubuntu_dict["password"]
     __find_and_replace('conf/pxe_cluster/ubuntu-uefi-server.seed',
-                       "d-i 	passwd/root-password password fake",
+                       "d-i passwd/user-password password ChangeMe123",
                        user_creds)
 
     logger.debug("configuring client root password verify in "
                  "ubuntu-uefi-server.seed")
-    user_creds = "d-i 	passwd/root-password-again password "\
+    user_creds = "d-i passwd/root-password-again password "\
                  + ubuntu_dict["password"]
     __find_and_replace('conf/pxe_cluster/ubuntu-uefi-server.seed',
-                       "d-i 	passwd/root-password-again password fake",
+                       "d-i passwd/user-password-again password ChangeMe123",
                        user_creds)
+
+    logger.debug("configuring late command script in "
+                 "ubuntu-uefi-server.seed")
+    post_command = "http://" + pxe_dict["serverIp"] + "/ubuntu/post.sh "
+    __find_and_replace('conf/pxe_cluster/ubuntu-uefi-server.seed',
+                       "    http://192.168.0.1/ubuntu/post.sh | \\",
+                       post_command)
 
     logger.debug("copy local ubuntu-uefi-server.seed to location "
                  "/var/www/html/ubuntu/preseed")

--- a/snaps_boot/provision/hardware/pxe_utils.py
+++ b/snaps_boot/provision/hardware/pxe_utils.py
@@ -379,9 +379,9 @@ def __create_seed_config(pxe_dict, ubuntu_dict, boot_interface):
 
     logger.debug("configuring late command script in "
                  "ubuntu-uefi-server.seed")
-    post_command = "http://" + pxe_dict["serverIp"] + "/ubuntu/post.sh "
+    post_command = "http://" + pxe_dict["serverIp"] + "/ubuntu/post.sh | \\"
     __find_and_replace('conf/pxe_cluster/ubuntu-uefi-server.seed',
-                       "    http://192.168.0.1/ubuntu/post.sh | \\",
+                       "    http://192.168.0.1/ubuntu/post.sh",
                        post_command)
 
     logger.debug("copy local ubuntu-uefi-server.seed to location "


### PR DESCRIPTION
#### What does this PR do?
Moves all seed commands for UEFI installs into the seed file to allow for drive selection and simplification.  
#### Do you have any concerns with this PR?
No
#### How can the reviewer verify this PR?
Do a snaps-boot install on a UEFI network. 
#### Any background context you want to provide?\
This was done as part of a network install on a UEFI legacy system where it had to be on sdb instead of sda.  Ubuntu has none limitations with kickseed files on drives and partitioning. 
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
Yes
- Does the documentation need an update?
Yes
- Does this add new Python dependencies?
No
- Have you added unit or functional tests for this PR?
No
- Does this patch update any configuration files?
It adds two but they are auto configured based on host.yaml so it should not affect anyone. 