### PR TITLE
Fixes #212

### DIFF
--- a/doc/source/install/install.md
+++ b/doc/source/install/install.md
@@ -330,8 +330,13 @@ Steps to PXE boot host machines.
 
 Run `iaas_launch.py` as shown below as a passwordless sudo user:
 
+Execute as standard workflow:
 ```
-python {git dir}/snaps-boot/iaas_launch.py -f {location of your configuration} -b
+sudo -i python {git dir}/snaps-boot/iaas_launch.py -f {location of your configuration} -b
+```
+or execute as a sudo user:
+```
+python {git dir}/snaps-boot/iaas_launch.py -f {location of your configuration} -b -or
 ```
 
 #### Step 6 - Static NIC Configuration
@@ -386,15 +391,14 @@ and huge page configuration and will boot the machine to default
 configuration.
 
 ### 5.2 Roll-back Static IP Configuration and Change Default Routes
-Back to Management Interface
 
 Execute as standard workflow:
 ```
-python {git dir}/snaps-boot/iaas_launch.py -f {location of your configuration} -sc
+sudo -i python {git dir}/snaps-boot/iaas_launch.py -f {location of your configuration} -sc
 ```
 or execute as a sudo user:
 ```
-python {git dir}/snaps-boot/iaas_launch.py -f {location of your configuration} -sc
+python {git dir}/snaps-boot/iaas_launch.py -f {location of your configuration} -sc -or
 ```
 
 This will modify etc/network/interfaces file to remove static entries of the interfaces and will change back default route to management interface.

--- a/snaps_boot/ansible_p/setup/drp_workflows_destroy.yaml
+++ b/snaps_boot/ansible_p/setup/drp_workflows_destroy.yaml
@@ -14,8 +14,5 @@
 - hosts: localhost
 
   tasks:
-  - name: Destroy DRP Workflows for Sledgehammer
-    command: drpcli workflows destroy ubuntu16
-
   - name: Destroy DRP Workflows for Ubuntu 16.04
-    command: drpcli workflows destroy discovery
+    command: drpcli workflows destroy ubuntu16

--- a/snaps_boot/drp_content/bootenvs/hwe-ubuntu-16.04-bootenv.json
+++ b/snaps_boot/drp_content/bootenvs/hwe-ubuntu-16.04-bootenv.json
@@ -1,0 +1,97 @@
+{
+  "Available": true,
+  "BootParams": "debian-installer/locale=en_US.utf8 console-setup/layoutcode=us keyboard-configuration/layoutcode=us netcfg/dhcp_timeout=120 netcfg/choose_interface=auto url={{.Machine.Url}}/seed netcfg/get_hostname={{.Machine.Name}} root=/dev/ram rw quiet {{if .ParamExists \"kernel-console\"}}{{.Param \"kernel-console\"}}{{end}} -- {{if .ParamExists \"kernel-console\"}}{{.Param \"kernel-console\"}}{{end}}",
+  "Description": "Ubuntu-16.04 HWE kernel install points to the latest release version",
+  "Documentation": "NOTE: Default Ubuntu ISOs will attempt to check internet repositories, \nthis can cause problems during provisioning if your environment does not have outbound access.\nWorkaround this by defining Options 3 (Gateway) and 6 (DNS) for your machines' Subnet.\n",
+  "Errors": [],
+  "Initrds": [
+    "install/hwe-netboot/ubuntu-installer/amd64/initrd.gz"
+  ],
+  "Kernel": "install/hwe-netboot/ubuntu-installer/amd64/linux",
+  "Meta": {
+    "color": "orange",
+    "feature-flags": "change-stage-v2",
+    "icon": "linux",
+    "title": "SNAPS Content"
+  },
+  "Name": "hwe-ubuntu-16.04-install",
+  "OS": {
+    "Codename": "",
+    "Family": "ubuntu",
+    "IsoFile": "ubuntu-16.04.5-server-amd64.iso",
+    "IsoSha256": "c94de1cc2e10160f325eb54638a5b5aa38f181d60ee33dae9578d96d932ee5f8",
+    "IsoUrl": "http://mirror.math.princeton.edu/pub/ubuntu-iso/16.04/ubuntu-16.04.5-server-amd64.iso",
+    "Name": "ubuntu-16.04",
+    "Version": "16.04"
+  },
+  "OnlyUnknown": false,
+  "OptionalParams": [
+    "part-scheme",
+    "operating-system-disk",
+    "provisioner-default-user",
+    "provisioner-default-fullname",
+    "provisioner-default-uid",
+    "provisioner-default-password-hash",
+    "kernel-console",
+    "proxy-servers",
+    "dns-domain",
+    "local-repo",
+    "proxy-servers",
+    "ntp-servers",
+    "select-kickseed"
+  ],
+  "ReadOnly": false,
+  "RequiredParams": [],
+  "Templates": [
+    {
+      "Contents": "",
+      "ID": "kexec.tmpl",
+      "Meta": {},
+      "Name": "kexec",
+      "Path": "{{.Machine.Path}}/kexec"
+    },
+    {
+      "Contents": "",
+      "ID": "default-pxelinux.tmpl",
+      "Meta": {},
+      "Name": "pxelinux",
+      "Path": "pxelinux.cfg/{{.Machine.HexAddress}}"
+    },
+    {
+      "Contents": "",
+      "ID": "default-ipxe.tmpl",
+      "Meta": {},
+      "Name": "ipxe",
+      "Path": "{{.Machine.Address}}.ipxe"
+    },
+    {
+      "Contents": "",
+      "ID": "default-pxelinux.tmpl",
+      "Meta": {},
+      "Name": "pxelinux-mac",
+      "Path": "pxelinux.cfg/{{.Machine.MacAddr \"pxelinux\"}}"
+    },
+    {
+      "Contents": "",
+      "ID": "default-ipxe.tmpl",
+      "Meta": {},
+      "Name": "ipxe-mac",
+      "Path": "{{.Machine.MacAddr \"ipxe\"}}.ipxe"
+    },
+    {
+      "Contents": "",
+      "ID": "select-kickseed.tmpl",
+      "Meta": {},
+      "Name": "seed",
+      "Path": "{{.Machine.Path}}/seed"
+    },
+    {
+      "Contents": "",
+      "ID": "net-post-install.sh.tmpl",
+      "Meta": {},
+      "Name": "net-post-install.sh",
+      "Path": "{{.Machine.Path}}/post-install.sh"
+    }
+  ],
+  "Validated": true
+}

--- a/snaps_boot/drp_content/stages/hwe-ubuntu-16.04-install.json
+++ b/snaps_boot/drp_content/stages/hwe-ubuntu-16.04-install.json
@@ -1,0 +1,25 @@
+{
+  "Available": true,
+  "BootEnv": "hwe-ubuntu-16.04-install",
+  "Description": "Ubuntu 16.04 HWE stack installation stage.  References latest release",
+  "Documentation": "",
+  "Errors": [],
+  "Meta": {
+    "color": "yellow",
+    "icon": "download",
+    "title": "SNAPS Content"
+  },
+  "Name": "hwe-ubuntu-16.04-install",
+  "OptionalParams": [],
+  "Profiles": [],
+  "ReadOnly": false,
+  "Reboot": false,
+  "RequiredParams": [],
+  "RunnerWait": true,
+  "Tasks": [
+    "ubuntu-drp-only-repos",
+    "ssh-access"
+  ],
+  "Templates": [],
+  "Validated": true
+}

--- a/snaps_boot/drp_content/workflows/snaps-ubuntu-16.04-hwe.json
+++ b/snaps_boot/drp_content/workflows/snaps-ubuntu-16.04-hwe.json
@@ -8,11 +8,11 @@
     "icon": "tag",
     "title": ""
   },
-  "Name": "snaps-ubuntu-16.04",
-  "Description": "Install ubuntu 16.04",
+  "Name": "snaps-ubuntu-16.04-hwe",
+  "Description": "Install ubuntu 16.04 HWE kernel",
   "Documentation": "",
   "Stages": [
-    "ubuntu-16.04-install",
+    "hwe-ubuntu-16.04-install",
     "snaps-post-install",
     "complete"
   ]

--- a/snaps_boot/provision/rebar_utils.py
+++ b/snaps_boot/provision/rebar_utils.py
@@ -525,7 +525,7 @@ def __get_drb_machine_config(host_conf, pxe_conf, bind_host_confs):
             'name': host_conf['name'],
             'os': boot_os,
             'type': 'snaps-boot',
-            'workflow': 'snaps-ubuntu-16.04'
+            'workflow': 'snaps-ubuntu-16.04-hwe'
         }
 
         logger.info('Instantiating a MachineModel object with %s',


### PR DESCRIPTION
#### What does this PR do?
Install HWE kernel in snaps content pack in order to support newer hardware.

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Deploy snaps-boot in CI environment and bare metal.

#### Any background context you want to provide?
The original snaps content pack won't work on new hardware.

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
#212 

- Does the documentation need an update?
No, but fixed minor issues in the documentation.

- Does this add new Python dependencies?
No

- Have you added unit or functional tests for this PR?
No

- Does this patch update any configuration files?
No