### PR TITLE
Fixes #219

### DIFF
--- a/snaps_boot/provision/ipmi_utils.py
+++ b/snaps_boot/provision/ipmi_utils.py
@@ -45,11 +45,11 @@ def __reboot_all(boot_conf, boot_order):
             command = Command(ip, user, password)
             __set_boot_order(command, boot_order)
             __reboot(command)
+            logger.info('Successfully rebooted server with BMC IP: %s', ip)
         except IpmiException as e:
             # print the error message and server bmc information
             # will continue to reboot the rest of servers
-            logger.error(e)
-            logger.warn('Failed to reboot server with BMC IP: %s, user: %s', ip, user)
+            logger.error('Failed to reboot server with BMC IP: %s, user: %s, error: %s', ip, user, e)
             logger.debug('BMC password: %s', password)
 
 

--- a/snaps_boot/provision/ipmi_utils.py
+++ b/snaps_boot/provision/ipmi_utils.py
@@ -57,23 +57,5 @@ def __set_boot_order(command, order):
     command.set_bootdev(order)
 
 
-def __reboot(command, timeout=30):
-    power = command.get_power()
-    if power['powerstate'] == 'on':
-        command.set_power('off')
-
-    start_time = time.time()
-    while time.time() - start_time < timeout or power['powerstate'] != 'off':
-        power = command.get_power()
-
-    if 'on' == power['powerstate']:
-        raise Exception('Chassis never powered down')
-
-    command.set_power('on')
-
-    start_time = time.time()
-    while time.time() - start_time < timeout or power['powerstate'] != 'on':
-        power = command.get_power()
-
-    if 'off' == power['powerstate']:
-        raise Exception('Chassis never powered up')
+def __reboot(command):
+    command.set_power('boot')

--- a/snaps_boot/provision/ipmi_utils.py
+++ b/snaps_boot/provision/ipmi_utils.py
@@ -11,9 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import logging
 import time
 
 from pyghmi.ipmi.command import Command
+from pyghmi.exceptions import IpmiException
+
+logger = logging.getLogger('snaps_boot_ipmi_utils')
+#logger.setLevel(logging.DEBUG)
 
 
 def reboot_pxe(boot_conf):
@@ -35,9 +41,16 @@ def reboot_disk(boot_conf):
 def __reboot_all(boot_conf, boot_order):
     creds = get_ipmi_creds(boot_conf)
     for ip, user, password in creds:
-        command = Command(ip, user, password)
-        __set_boot_order(command, boot_order)
-        __reboot(command)
+        try:
+            command = Command(ip, user, password)
+            __set_boot_order(command, boot_order)
+            __reboot(command)
+        except IpmiException as e:
+            # print the error message and server bmc information
+            # will continue to reboot the rest of servers
+            logger.error(e)
+            logger.warn('Failed to reboot server with BMC IP: %s, user: %s', ip, user)
+            logger.debug('BMC password: %s', password)
 
 
 def get_ipmi_creds(boot_conf):

--- a/snaps_boot/provision/ipmi_utils.py
+++ b/snaps_boot/provision/ipmi_utils.py
@@ -19,7 +19,7 @@ from pyghmi.ipmi.command import Command
 from pyghmi.exceptions import IpmiException
 
 logger = logging.getLogger('snaps_boot_ipmi_utils')
-#logger.setLevel(logging.DEBUG)
+# logger.setLevel(logging.DEBUG)
 
 
 def reboot_pxe(boot_conf):
@@ -49,7 +49,9 @@ def __reboot_all(boot_conf, boot_order):
         except IpmiException as e:
             # print the error message and server bmc information
             # will continue to reboot the rest of servers
-            logger.error('Failed to reboot server with BMC IP: %s, user: %s, error: %s', ip, user, e)
+            logger.error(
+                'Failed to reboot server with BMC IP: %s, user: %s, error: %s',
+                ip, user, e)
             logger.debug('BMC password: %s', password)
 
 


### PR DESCRIPTION
#### What does this PR do?
Use 'boot' command instead of our own power off/on logic for server reboot.

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Run -b option to validate servers are rebooted without issues.

#### Any background context you want to provide?
No

#### Screenshots or logs (if appropriate)

#### Questions:
- Have you connected this PR to the issue it resolves?
#219 

- Does the documentation need an update?
No

- Does this add new Python dependencies?
No

- Have you added unit or functional tests for this PR?
No, uses existing tests.

- Does this patch update any configuration files?
No
