### PR TITLE
Issue 222

### DIFF
--- a/ci/playbooks/templates/hosts.yaml.j2
+++ b/ci/playbooks/templates/hosts.yaml.j2
@@ -155,3 +155,4 @@ PROVISION:
         user: ubuntu
         fullname: ubuntu_user
         boot_disk: vda
+        kernel_choice: linux-server

--- a/doc/conf/hosts.yaml
+++ b/doc/conf/hosts.yaml
@@ -159,6 +159,7 @@ PROVISION:
           user: ubuntu
           fullname: ubuntu_user
           boot_disk: sda
+          kernel_choice: linux-server
   CPUCORE:
     host:
        -

--- a/doc/source/install/install.md
+++ b/doc/source/install/install.md
@@ -244,7 +244,7 @@ This section defines parameters used in preseed configuration to automate Linux 
 | user | Y | Default user for all host machines. SNAPS-Boot creates this user. |
 | fullname | Y | Description of user created by SNAPS-Boot. |
 | boot_disk | Y | Disk name where OS is installed, e.g., sda |
-| kernel_choice | N | Non-default kernel choice to install, e.g., linux-image-extra-4.4.0-62-generic |
+| kernel_choice | N | Name of the kernel image package that will be installed, e.g., linux-image-4.4.0-62-generic. Note: This package needs to be available from the configured repository. |
 
 ##### CentOS
 | Parameter | Required | Description |

--- a/doc/source/install/install.md
+++ b/doc/source/install/install.md
@@ -244,6 +244,7 @@ This section defines parameters used in preseed configuration to automate Linux 
 | user | Y | Default user for all host machines. SNAPS-Boot creates this user. |
 | fullname | Y | Description of user created by SNAPS-Boot. |
 | boot_disk | Y | Disk name where OS is installed, e.g., sda |
+| kernel_choice | N | Non-default kernel choice to install, e.g., linux-image-extra-4.4.0-62-generic |
 
 ##### CentOS
 | Parameter | Required | Description |

--- a/snaps_boot/drp_content/params/kernel-choice.json
+++ b/snaps_boot/drp_content/params/kernel-choice.json
@@ -8,8 +8,8 @@
     "icon": "pencil"
   },
   "Name": "seed/kernel-choice",
-  "Description": "Kernel to install",
-  "Documentation": "Kernel to install",
+  "Description": "Kernel image package name to install",
+  "Documentation": "Kernel image package name to install",
   "Secure": false,
   "Schema": {
     "type": "string"

--- a/snaps_boot/drp_content/params/kernel-choice.json
+++ b/snaps_boot/drp_content/params/kernel-choice.json
@@ -1,0 +1,17 @@
+{
+  "Validated": false,
+  "Available": false,
+  "Errors": [],
+  "ReadOnly": false,
+  "Meta": {
+    "color": "red",
+    "icon": "pencil"
+  },
+  "Name": "seed/kernel-choice",
+  "Description": "Kernel to install",
+  "Documentation": "Kernel to install",
+  "Secure": false,
+  "Schema": {
+    "type": "string"
+  }
+}

--- a/snaps_boot/drp_content/templates/snaps-net-seed.tmpl
+++ b/snaps_boot/drp_content/templates/snaps-net-seed.tmpl
@@ -17,7 +17,11 @@ d-i netcfg/hostname string compute
 d-i netcfg/wireless_wep string
 d-i netcfg/hostname seen true
  
-d-i base-installer/kernel/overrride-image string linux-server
+{{if .ParamExists "seed/kernel-choice" -}}
+d-i base-installer/kernel/override-image string {{.Param "seed/kernel-choice"}}
+{{else -}}
+d-i base-installer/kernel/override-image string linux-server
+{{end -}}
 
 # Equivalent to url --url=http://<> in ks.cfg
 d-i mirror/country string manual

--- a/snaps_boot/provision/rebar_utils.py
+++ b/snaps_boot/provision/rebar_utils.py
@@ -416,20 +416,26 @@ def __create_machine_params(boot_conf, public_key):
     user_password = None
     user = None
     fullname = None
+    kernel_choice = None
     for value in pxe_confs.values():
         user_password = value['password']
         user = value['user']
         fullname = value['fullname']
         install_disk = value['boot_disk']
+        # kernel_choice is optional, so use get() to avoid KeyError
+        kernel_choice = value.get('kernel_choice')
         break
 
-    if not install_disk or not user_password or not user or not user:
+    if not install_disk or not user_password or not user or not fullname:
         raise Exception('Cannot set expected seed values')
 
     out.append(ParamsModel(name='seed/user-password', value=user_password))
     out.append(ParamsModel(name='seed/username', value=user))
     out.append(ParamsModel(name='seed/user-fullname', value=fullname))
     out.append(ParamsModel(name='operating-system-disk', value=install_disk))
+    if kernel_choice:
+        out.append(
+            ParamsModel(name='seed/kernel-choice', value=kernel_choice))
 
     root_password = prov_conf['PXE']['password']
     server_ip = prov_conf['PXE']['server_ip']


### PR DESCRIPTION
#### What does this PR do?
Add an optional parameter to customize kernel to install.

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Deploy snaps-boot with or without the optional parameter. 

#### Any background context you want to provide?
In some cases, users want to install a specific kernel on disk.

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
#222 #225 

- Does the documentation need an update?
Yes, updated in this patch.

- Does this add new Python dependencies?
No

- Have you added unit or functional tests for this PR?
No

- Does this patch update any configuration files?
Yes, adds an optional attribute.