### PR TITLE
Fixes #239. Install DRP tip version instead of broken stable.

### DIFF
--- a/snaps_boot/ansible_p/setup/drp_setup.yaml
+++ b/snaps_boot/ansible_p/setup/drp_setup.yaml
@@ -28,13 +28,13 @@
 
   - name: Download Digital Rebar
     get_url:
-      url: http://get.rebar.digital/stable
+      url: http://get.rebar.digital/tip
       dest: /tmp/drp-install.sh
       mode: 0755
     when: result.rc != 0
 
   - name: Install Digital Rebar
-    command: /tmp/drp-install.sh install
+    command: /tmp/drp-install.sh --version='tip' install
     when: result.rc != 0
 
   - name: Add static IP to Digital Rebar service configuration file

--- a/snaps_boot/drp_content/bootenvs/hwe-ubuntu-16.04-bootenv.json
+++ b/snaps_boot/drp_content/bootenvs/hwe-ubuntu-16.04-bootenv.json
@@ -18,9 +18,9 @@
   "OS": {
     "Codename": "",
     "Family": "ubuntu",
-    "IsoFile": "ubuntu-16.04.5-server-amd64.iso",
+    "IsoFile": "ubuntu-16.04.6-server-amd64.iso",
     "IsoSha256": "c94de1cc2e10160f325eb54638a5b5aa38f181d60ee33dae9578d96d932ee5f8",
-    "IsoUrl": "http://mirror.math.princeton.edu/pub/ubuntu-iso/16.04/ubuntu-16.04.5-server-amd64.iso",
+    "IsoUrl": "http://mirror.math.princeton.edu/pub/ubuntu-iso/16.04/ubuntu-16.04.6-server-amd64.iso",
     "Name": "ubuntu-16.04",
     "Version": "16.04"
   },


### PR DESCRIPTION
#### What does this PR do?
Install DRP tip version instead of stable which has a broken ubuntu iso link.

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Deploy snaps-boot.

#### Any background context you want to provide?
Ubuntu recently released latest 16.04 and 18.04 versions, but DRP stable branch still contains the obsolete iso links.

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
#239 
- Does the documentation need an update?
No
- Does this add new Python dependencies?
No
- Have you added unit or functional tests for this PR?
No
- Does this patch update any configuration files?
No
