### PR TITLE
Removed security repository from seed file

### DIFF
--- a/snaps_boot/drp_content/templates/snaps-net-seed.tmpl
+++ b/snaps_boot/drp_content/templates/snaps-net-seed.tmpl
@@ -113,8 +113,6 @@ d-i grub-installer/timeout string 10
 # Select which update services to use; define the mirrors to be used.
 # Values shown below are the normal defaults.
 d-i pkgsel/update-policy select unattended-upgrades
-d-i apt-setup/services-select multiselect security
-d-i apt-setup/security_host string security.ubuntu.com
 d-i apt-setup/security_path string /ubuntu
 d-i apt-setup/multiverse boolean true
 d-i apt-setup/restricted boolean true


### PR DESCRIPTION
#### What does this PR do?
Removes security repos from seed tile.

#### Do you have any concerns with this PR?
Need to check that the security repo is installed after the initial install.

#### How can the reviewer verify this PR?
Complete an install with this branch.

#### Any background context you want to provide?
This issue is only seen on management subnets without external network access.

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
Yes.  fixes #241 
- Does the documentation need an update?
Would be good to check, but should not have an issue.
- Does this add new Python dependencies?
No.
- Have you added unit or functional tests for this PR?
No.
- Does this patch update any configuration files?
yes.