### PR TITLE
issue_248:Proxy added to acng.conf

### DIFF
--- a/doc/source/install/install.md
+++ b/doc/source/install/install.md
@@ -177,7 +177,7 @@ Configuration parameter defined in this section are explained below.
 | ftp_proxy | N | Proxy to be used for FTP. |
 | http_proxy | N | Proxy to be used for HTTP traffic. |
 | https_proxy | N | Proxy to be used for HTTPS traffic. |
-| ngcacher_proxy | N | Proxy should be set in case the servers are behind corporate firewalls. |
+| ngcacher_proxy | Y | Required always; irrespective of whether the servers are behind corporate firewall/Proxy or not. |
 
 
 > Note: If proxy configuration is not required use null value **“”**

--- a/snaps_boot/ansible_p/setup/setup_proxy_server.yaml
+++ b/snaps_boot/ansible_p/setup/setup_proxy_server.yaml
@@ -25,6 +25,12 @@
       name: apt-cacher-ng
       update_cache: yes
 
+  - name: Configure apt-cacher-ng - Proxy Settings
+    lineinfile:
+      path: /etc/apt-cacher-ng/acng.conf
+      line: "Proxy: {{ http_proxy }}"
+    when: http_proxy is defined and "{{ http_proxy }}"!=""
+
   - name: Configure apt-cacher-ng - PassThroughPattern
     lineinfile:
       path: /etc/apt-cacher-ng/acng.conf

--- a/snaps_boot/provision/rebar_utils.py
+++ b/snaps_boot/provision/rebar_utils.py
@@ -41,7 +41,7 @@ def install_config_drp(rebar_session, boot_conf):
     :raises Exceptions
     """
     logger.info('Setting up Digital Rebar service and objects')
-    __setup_proxy_server()
+    __setup_proxy_server(boot_conf)
     __setup_drp(boot_conf)
     __create_images()
     __create_subnet(rebar_session, boot_conf)
@@ -52,11 +52,12 @@ def install_config_drp(rebar_session, boot_conf):
     __create_machines(rebar_session, boot_conf)
 
 
-def __setup_proxy_server():
+def __setup_proxy_server(boot_conf):
     logger.info('Setting up ng-cacher-proxy')
     playbook_path = pkg_resources.resource_filename(
         'snaps_boot.ansible_p.setup', 'setup_proxy_server.yaml')
-    ansible_utils.apply_playbook(playbook_path)
+    ansible_utils.apply_playbook(playbook_path, variables={
+        'http_proxy': boot_conf['PROVISION']['PROXY']['http_proxy']})
 
 
 def cleanup_drp(rebar_session, boot_conf):


### PR DESCRIPTION
#### What does this PR do?
Fixes #248 
This PR will add the Proxy in 'acng.conf'  file.
#### Do you have any concerns with this PR?
No
#### How can the reviewer verify this PR?
After executing the yaml file, Proxy value get added in to acng.conf file
#### Any background context you want to provide?
This is part of adding http_proxy support for Snaps-boot
#### Screenshots or logs (if appropriate)
Log Snippets : 
'''
INFO:ansible_utils:Applying playbook [/usr/local/lib/python2.7/dist-packages/snaps_boot/ansible_p/setup/setup_proxy_server.yaml] with variables - {'http_proxy': 'http://165.245.105.75:80'}
'''

'''
TASK [Configure apt-cacher-ng - Proxy Settings] *******************************************
ok: [localhost]
'''
#### Questions:
- Have you connected this PR to the issue it resolves?
yes
- Does the documentation need an update?
May not be
- Does this add new Python dependencies?
No
- Have you added unit or functional tests for this PR?
Tested the entire script
- Does this patch update any configuration files?
No
