### PR TITLE
Removed the task to delete apt.conf file

### DIFF
--- a/snaps_boot/ansible_p/commission/setIPConfig.yaml
+++ b/snaps_boot/ansible_p/commission/setIPConfig.yaml
@@ -66,12 +66,6 @@
       remote_src: True
     when: is_ext|bool and true
 
-  - name: Remove /etc/apt/apt.conf.bak
-    file:
-      path: /etc/apt/apt.conf
-      state: absent
-    when: is_ext|bool and true
-
   - name: restarting system
     shell: /sbin/shutdown -r 1 "Ansible restart"
     ignore_errors: True


### PR DESCRIPTION
#### What does this PR do?
Fixes #249 
This PR will stop removing apt.conf file
#### Do you have any concerns with this PR?
Any other projects which will be running after  'snaps-boot' should not blindly add/modify/delete entries from apt.conf. 
#### How can the reviewer verify this PR?
After running this PR, the apt.conf file will still be present in the directory with ng-cacher-proxy
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
Issue#249
- Does the documentation need an update?
No
- Does this add new Python dependencies?
No
- Have you added unit or functional tests for this PR?
Tested Snaps boot with this change
- Does this patch update any configuration files?
No