### PR TITLE
Removed the http_proxy part from wget command

### DIFF
--- a/snaps_boot/drp_content/templates/snaps-net-post-install.sh.tmpl
+++ b/snaps_boot/drp_content/templates/snaps-net-post-install.sh.tmpl
@@ -32,11 +32,7 @@ EOF
 
 {{ if .ParamExists "post/script-url" }}
 SCRIPT=/var/log/downloaded_script
-{{ if .ParamExists "post/http-proxy" }}
-wget -e http_proxy={{.Param "post/http-proxy"}} {{.Param "post/script-url"}} -O $SCRIPT
-{{ else }}
 wget {{.Param "post/script-url"}} -O $SCRIPT
-{{ end }}
 chmod +x $SCRIPT
 $SCRIPT
 {{ end }}


### PR DESCRIPTION
#### What does this PR do?
Fixes #250 
Removed the http_proxy appended section from wget command in snaps-net-post-install.sh.tmpl
file.
#### Do you have any concerns with this PR?
No
#### How can the reviewer verify this PR?
By setting http_proxy in configuration (host.yaml) file
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
>>>
    "operating-system-disk": "sdb",
    "post/http-proxy": "http://165.225.104.34:80",
    "post/https-proxy": "http://165.225.104.34:80",
    "post/ngcacher-proxy": "http://172.19.104.2:3142",
    "post/script-url": "http://172.19.104.2:8091/files/post_script",
<<<
>>>
Starting command ./snaps-post-install-snaps-net-post-install.sh.tmpl
Command running
--2019-06-27 23:06:25--  http://172.19.104.2:8091/files/post_script
Connecting to 172.19.104.2:8091... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1650 (1.6K) [text/plain]
Saving to: ‘/var/log/downloaded_script’
     0K .                                                     100%  166M=0s
2019-06-27 23:06:25 (166 MB/s) - ‘/var/log/downloaded_script’ saved [1650/1650]
<<<

#### Questions:
- Have you connected this PR to the issue it resolves?    issue#250
- Does the documentation need an update?                   No
- Does this add new Python dependencies?                    No
- Have you added unit or functional tests for this PR?    Tested the Snaps-boot in a proxy environment
- Does this patch update any configuration files?           No
