### PR TITLE
Added http_proxy as environment variable

### DIFF
--- a/snaps_boot/drp_content/templates/snaps-net-post-install.sh.tmpl
+++ b/snaps_boot/drp_content/templates/snaps-net-post-install.sh.tmpl
@@ -11,6 +11,15 @@ Acquire::https::Proxy "";
 Acquire::ftp::Proxy "";
 EOF
 
+cat >> /etc/environment <<EOF
+{{ if .ParamExists "post/http-proxy" }}
+http_proxy="{{.Param "post/http-proxy"}}"
+{{ end }}
+{{ if .ParamExists "post/https-proxy" }}
+https_proxy="{{.Param "post/https-proxy"}}"
+{{ end }}
+EOF
+
 cat > /etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ xenial main restricted
 deb http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted


### PR DESCRIPTION
#### What does this PR do?
Fixes #251 
Add http_proxy and https_proxy environment variables on target nodes
#### Do you have any concerns with this PR?
No
#### How can the reviewer verify this PR?
By seting the proxy values in host.yaml (configuration file) and running snaps_boot
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
>>>
root@minion1:~# cat /etc/environment
http_proxy=http://165.245.105.75:80
https_proxy=http://165.245.105.75:80
<<<
#### Questions:
- Have you connected this PR to the issue it resolves?    issue# 251
- Does the documentation need an update?                   No
- Does this add new Python dependencies?                    No
- Have you added unit or functional tests for this PR?    Tested the snaps-boot in proxy environment
- Does this patch update any configuration files?           No
