### PR TITLE
Fix issue on baremetal and libvirt where the ubuntu installer prompts

### DIFF
--- a/snaps_boot/drp_content/templates/snaps-net-seed.tmpl
+++ b/snaps_boot/drp_content/templates/snaps-net-seed.tmpl
@@ -81,6 +81,7 @@ d-i partman-partitioning/confirm_write_new_label boolean true
 d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
 d-i partman/confirm_nooverwrite boolean true
 d-i partman-efi/non_efi_system boolean true
 


### PR DESCRIPTION
### What does this PR do?
Fixes #270 
Adds a line to the snaps seed file to tell the installer never to prompt the user on whether or not they would like to write LVM changes to disk.
#### Do you have any concerns with this PR?
As this issue has not been observed on OpenStack, the current CI scripts will not suffice for testing, therefore, @bo-quan - Can you verify this patch on one of our baremetal labs? I validated the change in the 'aws_ci' branch that is using libvirt.
#### How can the reviewer verify this PR?
Run on baremetal to ensure manual input is no longer required
#### Any background context you want to provide?
Found the issue while trying to run project within libvirt
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
yes
- Does the documentation need an update?
no
- Does this add new Python dependencies?
no
- Have you added unit or functional tests for this PR?
no
- Does this patch update any configuration files?
no