### PR TITLE
Azure ci refactor

### DIFF
--- a/ci/aws/provisioner.tf
+++ b/ci/aws/provisioner.tf
@@ -31,6 +31,7 @@ ${var.WAIT_FOR_BUILD} \
 --key-file="${var.private_key_file}" \
 --extra-vars " \
 host=${var.build_ip_prfx}.${var.build_ip_suffix}
+timeout=${var.wait_timeout}
 pause_time=5
 "\
 EOT

--- a/ci/aws/variables.tf
+++ b/ci/aws/variables.tf
@@ -14,9 +14,10 @@
 # Required Variables
 variable "access_key" {}
 variable "secret_key" {}
-variable "git_user" {}
-variable "git_pass" {}
+
 variable "build_id" {}
+
+variable "wait_timeout" {default = "600"}
 
 # Variables that are recommended to change as they won't work in all envs
 variable "public_key_file" {default = "~/.ssh/id_rsa.pub"}

--- a/ci/azure/README.md
+++ b/ci/azure/README.md
@@ -1,0 +1,25 @@
+# snaps-boot CI
+Readme for information on running _snaps-boot_ CI
+
+## Build Host Requirements
+- Python installed
+- Ansible has been installed into the Python runtime
+- Download and install Terraform from <https://www.terraform.io/downloads.html>
+
+## Setup bare metal host on AWS and execute deployment from the build host
+Run the following bash command from this directory:
+```bash
+export TF_CLI_CONFIG_FILE="{snaps-config dir}/aws/terraform_rc"
+terraform init
+terraform apply -auto-approve \
+-var-file='{snaps-config dir}/aws/snaps-ci.tfvars' \
+-var build_id={some unique readable value}
+```
+
+## Cleanup
+Always perform cleanup after completion by running the following command from this directory:
+```bash
+terraform destroy -auto-approve \
+-var-file='{snaps-config dir}/aws/snaps-ci.tfvars' \
+-var build_id={some unique readable value}
+```

--- a/ci/azure/README.md
+++ b/ci/azure/README.md
@@ -5,6 +5,8 @@ Readme for information on running _snaps-boot_ CI
 - Python installed
 - Ansible has been installed into the Python runtime
 - Download and install Terraform from <https://www.terraform.io/downloads.html>
+- Download and install Azure command line client
+    - az login (for now until we get shared credentials) 
 
 ## Setup bare metal host on AWS and execute deployment from the build host
 Run the following bash command from this directory:
@@ -12,7 +14,7 @@ Run the following bash command from this directory:
 export TF_CLI_CONFIG_FILE="{snaps-config dir}/aws/terraform_rc"
 terraform init
 terraform apply -auto-approve \
--var-file='{snaps-config dir}/aws/snaps-ci.tfvars' \
+-var-file='{snaps-common dir}/ci/snaps-boot-env/boot-env.tfvars' \
 -var build_id={some unique readable value}
 ```
 
@@ -20,6 +22,6 @@ terraform apply -auto-approve \
 Always perform cleanup after completion by running the following command from this directory:
 ```bash
 terraform destroy -auto-approve \
--var-file='{snaps-config dir}/aws/snaps-ci.tfvars' \
+-var-file='{snaps-common dir}/ci/snaps-boot-env/boot-env.tfvars' \
 -var build_id={some unique readable value}
 ```

--- a/ci/azure/azure-resources.tf
+++ b/ci/azure/azure-resources.tf
@@ -1,0 +1,164 @@
+# Copyright (c) 2019 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Azure Credentials
+//provider "azurerm" {
+//  subscription_id = var.subscription_id
+//  client_id = var.client_id
+//  client_secret = var.client_secret
+//  tenant_id = var.tenant_id
+//  environment = "public"
+//}
+
+resource "azurerm_resource_group" "snaps-boot" {
+  location = var.location
+  name = "snaps-boot-res-grp-${var.build_id}"
+}
+
+resource "azurerm_virtual_network" "snaps-boot-net" {
+  name = "snaps-boot-net-${var.build_id}"
+  address_space = ["10.1.0.0/16"]
+  //  location = var.location
+  //  resource_group_name = var.resource_group_name
+  location = azurerm_resource_group.snaps-boot.location
+  resource_group_name = azurerm_resource_group.snaps-boot.name
+}
+
+resource "azurerm_subnet" "snaps-boot-subnet" {
+  name = "snaps-boot-subnet-${var.build_id}"
+  virtual_network_name = azurerm_virtual_network.snaps-boot-net.name
+  //  resource_group_name = var.resource_group_name
+  resource_group_name = azurerm_resource_group.snaps-boot.name
+  address_prefix = "10.1.0.0/24"
+}
+
+resource "azurerm_public_ip" "snaps-boot-pub-ip" {
+  name = "snaps-boot-${var.build_id}"
+  //  location = var.location
+  //  resource_group_name = var.resource_group_name
+  location = azurerm_resource_group.snaps-boot.location
+  resource_group_name = azurerm_resource_group.snaps-boot.name
+  allocation_method = "Static"
+}
+
+resource "azurerm_network_interface" "snaps-boot-nic" {
+  name                = "snaps-boot-${var.build_id}-nic"
+  //  location = var.location
+  //  resource_group_name = var.resource_group_name
+  location = azurerm_resource_group.snaps-boot.location
+  resource_group_name = azurerm_resource_group.snaps-boot.name
+
+  ip_configuration {
+    name                          = "configuration"
+    subnet_id                     = azurerm_subnet.snaps-boot-subnet.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.snaps-boot-pub-ip.id
+  }
+}
+
+//resource "azurerm_image" "snaps-boot-image" {
+//  location = var.location
+//  name = "snaps_boot_img"
+//  resource_group_name = "snaps-boot-ci"
+//}
+
+//resource "azurerm_shared_image_gallery" "snaps-boot-gallery" {
+//  name                = "images_boot"
+//  resource_group_name = azurerm_resource_group.snaps-boot.name
+//  location            = azurerm_resource_group.snaps-boot.location
+//}
+//
+//resource "azurerm_shared_image" "snaps-boot-image" {
+//  name                = "snaps_boot_img"
+//  gallery_name        = "snaps_boot_gallery"
+//  resource_group_name = "snaps-boot-ci"
+//  location            = var.location
+//  os_type             = "Linux"
+//  identifier {
+//    publisher = "snaps-boot-pub"
+//    offer     = "snaps-boot-offer"
+//    sku       = "snaps-boot-sku"
+//  }
+//}
+
+//resource "azurerm_shared_image_version" "snaps-boot-image-version" {
+//  name                = "0.0.1"
+//  gallery_name        = azurerm_shared_image_gallery.snaps-boot-gallery.name
+//  image_name          = azurerm_shared_image.snaps-boot-image.name
+//  resource_group_name = azurerm_shared_image.snaps-boot-image.resource_group_name
+//  location            = azurerm_shared_image.snaps-boot-image.location
+//  managed_image_id    = var.built_image_id
+//  target_region {
+//    name = azurerm_shared_image.snaps-boot-image.location
+//    regional_replica_count = 1
+//  }
+//}
+
+resource "azurerm_virtual_machine" "snaps-boot-host" {
+  name = "snaps-boot-host-${var.build_id}"
+
+  delete_os_disk_on_termination = true
+  delete_data_disks_on_termination = true
+
+  location = azurerm_resource_group.snaps-boot.location
+  resource_group_name = azurerm_resource_group.snaps-boot.name
+  network_interface_ids = [azurerm_network_interface.snaps-boot-nic.id]
+  vm_size = var.vm_size
+
+  os_profile {
+    admin_username = "ubuntu"
+    admin_password = "Cable123"
+    computer_name = "snaps-boot-host"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+    ssh_keys {
+      key_data = file(var.public_key_file)
+      path = "/home/${var.sudo_user}/.ssh/authorized_keys"
+    }
+  }
+
+  storage_image_reference {
+//    id = "/subscriptions/ffc5d93a-8a85-4c42-8c33-7d0d762e852d/resourceGroups/snaps-boot-ci/providers/Microsoft.Compute/galleries/snaps_boot_gallery/images/snaps_boot_img/versions/0.0.1"
+    id = "/subscriptions/ffc5d93a-8a85-4c42-8c33-7d0d762e852d/resourceGroups/snaps-boot-ci/providers/Microsoft.Compute/galleries/snaps_boot_gallery/images/snaps_boot_img/versions/0.0.2"
+  }
+
+  storage_os_disk {
+    name = "snaps-boot-disk-${var.build_id}"
+    disk_size_gb = var.volume_size
+    caching = "ReadWrite"
+    create_option = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  tags = {
+    Name = "snaps-boot-build-${var.build_id}"
+  }
+
+  # Used to ensure host is really up before attempting to apply ansible playbooks
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'hello ${var.build_id}' /etc/motd"
+    ]
+  }
+
+  # Remote connection info for remote-exec
+  connection {
+    host = azurerm_public_ip.snaps-boot-pub-ip.ip_address
+    type     = "ssh"
+    user     = var.sudo_user
+    private_key = file(var.private_key_file)
+    timeout = "15m"
+  }
+}

--- a/ci/azure/azure-resources.tf
+++ b/ci/azure/azure-resources.tf
@@ -28,8 +28,6 @@ resource "azurerm_resource_group" "snaps-boot" {
 resource "azurerm_virtual_network" "snaps-boot-net" {
   name = "snaps-boot-net-${var.build_id}"
   address_space = ["10.1.0.0/16"]
-  //  location = var.location
-  //  resource_group_name = var.resource_group_name
   location = azurerm_resource_group.snaps-boot.location
   resource_group_name = azurerm_resource_group.snaps-boot.name
 }
@@ -37,24 +35,19 @@ resource "azurerm_virtual_network" "snaps-boot-net" {
 resource "azurerm_subnet" "snaps-boot-subnet" {
   name = "snaps-boot-subnet-${var.build_id}"
   virtual_network_name = azurerm_virtual_network.snaps-boot-net.name
-  //  resource_group_name = var.resource_group_name
   resource_group_name = azurerm_resource_group.snaps-boot.name
   address_prefix = "10.1.0.0/24"
 }
 
 resource "azurerm_public_ip" "snaps-boot-pub-ip" {
   name = "snaps-boot-${var.build_id}"
-  //  location = var.location
-  //  resource_group_name = var.resource_group_name
   location = azurerm_resource_group.snaps-boot.location
   resource_group_name = azurerm_resource_group.snaps-boot.name
   allocation_method = "Static"
 }
 
 resource "azurerm_network_interface" "snaps-boot-nic" {
-  name                = "snaps-boot-${var.build_id}-nic"
-  //  location = var.location
-  //  resource_group_name = var.resource_group_name
+  name = "snaps-boot-${var.build_id}-nic"
   location = azurerm_resource_group.snaps-boot.location
   resource_group_name = azurerm_resource_group.snaps-boot.name
 
@@ -65,44 +58,6 @@ resource "azurerm_network_interface" "snaps-boot-nic" {
     public_ip_address_id          = azurerm_public_ip.snaps-boot-pub-ip.id
   }
 }
-
-//resource "azurerm_image" "snaps-boot-image" {
-//  location = var.location
-//  name = "snaps_boot_img"
-//  resource_group_name = "snaps-boot-ci"
-//}
-
-//resource "azurerm_shared_image_gallery" "snaps-boot-gallery" {
-//  name                = "images_boot"
-//  resource_group_name = azurerm_resource_group.snaps-boot.name
-//  location            = azurerm_resource_group.snaps-boot.location
-//}
-//
-//resource "azurerm_shared_image" "snaps-boot-image" {
-//  name                = "snaps_boot_img"
-//  gallery_name        = "snaps_boot_gallery"
-//  resource_group_name = "snaps-boot-ci"
-//  location            = var.location
-//  os_type             = "Linux"
-//  identifier {
-//    publisher = "snaps-boot-pub"
-//    offer     = "snaps-boot-offer"
-//    sku       = "snaps-boot-sku"
-//  }
-//}
-
-//resource "azurerm_shared_image_version" "snaps-boot-image-version" {
-//  name                = "0.0.1"
-//  gallery_name        = azurerm_shared_image_gallery.snaps-boot-gallery.name
-//  image_name          = azurerm_shared_image.snaps-boot-image.name
-//  resource_group_name = azurerm_shared_image.snaps-boot-image.resource_group_name
-//  location            = azurerm_shared_image.snaps-boot-image.location
-//  managed_image_id    = var.built_image_id
-//  target_region {
-//    name = azurerm_shared_image.snaps-boot-image.location
-//    regional_replica_count = 1
-//  }
-//}
 
 resource "azurerm_virtual_machine" "snaps-boot-host" {
   name = "snaps-boot-host-${var.build_id}"
@@ -130,7 +85,6 @@ resource "azurerm_virtual_machine" "snaps-boot-host" {
   }
 
   storage_image_reference {
-//    id = "/subscriptions/ffc5d93a-8a85-4c42-8c33-7d0d762e852d/resourceGroups/snaps-boot-ci/providers/Microsoft.Compute/galleries/snaps_boot_gallery/images/snaps_boot_img/versions/0.0.1"
     id = "/subscriptions/ffc5d93a-8a85-4c42-8c33-7d0d762e852d/resourceGroups/snaps-boot-ci/providers/Microsoft.Compute/galleries/snaps_boot_gallery/images/snaps_boot_img/versions/0.0.2"
   }
 

--- a/ci/azure/outputs.tf
+++ b/ci/azure/outputs.tf
@@ -1,0 +1,18 @@
+# Copyright (c) 2019 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Outputs
+
+output "pub_ip" {
+  value = azurerm_public_ip.snaps-boot-pub-ip.ip_address
+}

--- a/ci/azure/provisioner.tf
+++ b/ci/azure/provisioner.tf
@@ -1,0 +1,248 @@
+# Copyright (c) 2019 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Call ensure SSH key has correct permissions
+resource "null_resource" "snaps-boot-pk-setup" {
+  depends_on = [azurerm_virtual_machine.snaps-boot-host]
+  provisioner "local-exec" {
+    command = "chmod 600 ${var.private_key_file}"
+  }
+}
+
+# Call ansible scripts to run snaps-hyperbuild
+resource "null_resource" "snaps-hyperbuild-wait-for-build" {
+  depends_on = [null_resource.snaps-boot-pk-setup]
+
+  # Setup KVM on the VM to create VMs on it for testing snaps-hyperbuild
+  provisioner "local-exec" {
+    command = <<EOT
+${var.ANSIBLE_CMD} -u ${var.sudo_user} \
+-i ${azurerm_public_ip.snaps-boot-pub-ip.ip_address}, \
+${var.WAIT_FOR_BUILD} \
+--extra-vars " \
+host=${var.build_ip_prfx}.${var.build_ip_suffix}
+timeout=${var.wait_timeout}
+pause_time=30
+"\
+EOT
+  }
+}
+
+# Add local key to build server
+resource "null_resource" "snaps-boot-inject-pub-key-to-build" {
+  depends_on = [null_resource.snaps-hyperbuild-wait-for-build]
+  provisioner "remote-exec" {
+    inline = [
+      "ssh -o StrictHostKeyChecking=no ${var.build_ip_prfx}.${var.build_ip_suffix} 'rm -f ~/.ssh/known_hosts'",
+      "ssh -o StrictHostKeyChecking=no ${var.build_ip_prfx}.${var.build_ip_suffix} 'touch ~/.ssh/authorized_keys'",
+      "ssh -o StrictHostKeyChecking=no ${var.build_ip_prfx}.${var.build_ip_suffix} 'echo \"${file(var.public_key_file)}\" >> ~/.ssh/authorized_keys'",
+      "ssh -o StrictHostKeyChecking=no ${var.build_ip_prfx}.${var.build_ip_suffix} 'chmod 600 ~/.ssh/authorized_keys'",
+      "ssh -o StrictHostKeyChecking=no ${var.build_ip_prfx}.${var.build_ip_suffix} 'cp ~/.ssh/authorized_keys ~/.ssh/authorized_keys.bak'",
+    ]
+  }
+  connection {
+    host = azurerm_public_ip.snaps-boot-pub-ip.ip_address
+    type = "ssh"
+    user = var.sudo_user
+    private_key = file(var.private_key_file)
+  }
+}
+
+# Call ansible scripts to run snaps-boot
+resource "null_resource" "snaps-boot-src-setup" {
+  depends_on = [null_resource.snaps-boot-inject-pub-key-to-build]
+
+  # Setup KVM on the VM to create VMs on it for testing snaps-boot
+  provisioner "local-exec" {
+    command = <<EOT
+${var.ANSIBLE_CMD} -u ${var.sudo_user} \
+-i ${var.build_ip_prfx}.${var.build_ip_suffix}, \
+${var.SETUP_SRC} \
+--ssh-common-args="-o ProxyCommand='ssh ${var.sudo_user}@${azurerm_public_ip.snaps-boot-pub-ip.ip_address} nc ${var.build_ip_prfx}.${var.build_ip_suffix} 22'" \
+--extra-vars " \
+src_copy_dir=${var.src_copy_dir}
+proxy_host=${var.build_ip_prfx}.1
+proxy_port=${var.proxy_port}
+"\
+EOT
+  }
+}
+
+# Call ansible scripts to run snaps-boot
+resource "null_resource" "snaps-boot-drp-setup" {
+  depends_on = [null_resource.snaps-boot-src-setup]
+
+  # Setup KVM on the VM to create VMs on it for testing snaps-boot
+  provisioner "local-exec" {
+    command = <<EOT
+${var.ANSIBLE_CMD} -u ${var.sudo_user} \
+-i ${var.build_ip_prfx}.${var.build_ip_suffix}, \
+${var.SETUP_DRP} \
+--ssh-common-args="-o ProxyCommand='ssh ${var.sudo_user}@${azurerm_public_ip.snaps-boot-pub-ip.ip_address} nc ${var.build_ip_prfx}.${var.build_ip_suffix} 22'" \
+--extra-vars "\
+nameserver=${var.build_ip_prfx}.1
+src_copy_dir=${var.src_copy_dir}
+post_script_file=${var.post_script_file}
+priv_ip_prfx=${var.priv_ip_prfx}
+admin_ip_prfx=${var.admin_ip_prfx}
+pub_ip_prfx=${var.pub_ip_prfx}
+ip_suffix_1=${var.node_1_suffix}
+ip_suffix_2=${var.node_2_suffix}
+ip_suffix_3=${var.node_3_suffix}
+priv_mac_1=${var.node_1_mac_1}
+priv_mac_2=${var.node_2_mac_1}
+priv_mac_3=${var.node_3_mac_1}
+bcast_addr=${var.priv_ip_prfx}.255
+domain_name=cablelabs.com
+dns_addr=8.8.8.8
+listen_iface=ens3
+max_lease=7200
+netmask=255.255.255.0
+router_ip=${var.priv_ip_prfx}.100 ${var.priv_ip_prfx}.254
+build_ip_suffix=${var.build_ip_suffix}
+http_proxy_port=${var.ngcacher_proxy_port}
+priv_iface=ens3
+admin_iface=ens8
+pub_iface=ens9
+pxe_pass=${var.pxe_pass}
+hosts_yaml_path=${var.hosts_yaml_path}
+org_proxy=${var.build_ip_prfx}.1:${var.proxy_port}
+"\
+EOT
+  }
+}
+
+resource "null_resource" "snaps-boot-nodes-power-cycle" {
+  depends_on = [null_resource.snaps-boot-drp-setup]
+  provisioner "remote-exec" {
+    inline = [
+      "sudo virsh reset ${var.node_1_name}",
+      "sudo virsh reset ${var.node_2_name}",
+      "sudo virsh reset ${var.node_3_name}",
+    ]
+  }
+  connection {
+    host = azurerm_public_ip.snaps-boot-pub-ip.ip_address
+    type     = "ssh"
+    user     = var.sudo_user
+    private_key = file(var.private_key_file)
+  }
+}
+
+# Validate private interface is active
+resource "null_resource" "snaps-boot-verify-priv-intfs" {
+  depends_on = [null_resource.snaps-boot-nodes-power-cycle]
+
+  # Setup KVM on the VM to create VMs on it for testing snaps-boot
+  provisioner "local-exec" {
+    command = <<EOT
+${var.ANSIBLE_CMD} -u ${var.sudo_user} \
+-i ${var.build_ip_prfx}.${var.build_ip_suffix}, \
+${var.VERIFY_INTFS} \
+--ssh-common-args="-o ProxyCommand='ssh ${var.sudo_user}@${azurerm_public_ip.snaps-boot-pub-ip.ip_address} nc ${var.build_ip_prfx}.${var.build_ip_suffix} 22'" \
+--extra-vars "{
+'username': 'root',
+'host_ips': ['${var.priv_ip_prfx}.${var.node_1_suffix}',
+             '${var.priv_ip_prfx}.${var.node_2_suffix}',
+             '${var.priv_ip_prfx}.${var.node_3_suffix}',
+            ],
+'timeout': '${var.initial_boot_timeout}',
+}"\
+EOT
+  }
+}
+
+# Configure NICs
+resource "null_resource" "snaps-boot-config-intf" {
+  depends_on = [null_resource.snaps-boot-verify-priv-intfs]
+
+  # Setup KVM on the VM to create VMs on it for testing snaps-boot
+  provisioner "local-exec" {
+    command = <<EOT
+${var.ANSIBLE_CMD} -u ${var.sudo_user} \
+-i ${var.build_ip_prfx}.${var.build_ip_suffix}, \
+${var.CONFIG_INTFS} \
+--ssh-common-args="-o ProxyCommand='ssh ${var.sudo_user}@${azurerm_public_ip.snaps-boot-pub-ip.ip_address} nc ${var.build_ip_prfx}.${var.build_ip_suffix} 22'" \
+--extra-vars "\
+snaps_boot_dir=${var.src_copy_dir}/snaps-boot
+hosts_yaml_path=${var.hosts_yaml_path}
+check_file=${var.VERIFY_INTFS_CHECK_FILE}
+"\
+EOT
+  }
+}
+
+# Add local key to build server
+resource "null_resource" "snaps-boot-reinject-pub-key-to-build" {
+  depends_on = [null_resource.snaps-boot-config-intf]
+  provisioner "remote-exec" {
+    inline = [
+      "ssh -o StrictHostKeyChecking=no ${var.build_ip_prfx}.${var.build_ip_suffix} 'rm -f ~/.ssh/known_hosts'",
+      "ssh -o StrictHostKeyChecking=no ${var.build_ip_prfx}.${var.build_ip_suffix} 'touch ~/.ssh/authorized_keys'",
+      "ssh -o StrictHostKeyChecking=no ${var.build_ip_prfx}.${var.build_ip_suffix} 'echo \"${file(var.public_key_file)}\" >> ~/.ssh/authorized_keys'",
+      "ssh -o StrictHostKeyChecking=no ${var.build_ip_prfx}.${var.build_ip_suffix} 'chmod 600 ~/.ssh/authorized_keys'",
+      "ssh -o StrictHostKeyChecking=no ${var.build_ip_prfx}.${var.build_ip_suffix} 'cp ~/.ssh/authorized_keys ~/.ssh/authorized_keys.bak'",
+    ]
+  }
+  connection {
+    host = azurerm_public_ip.snaps-boot-pub-ip.ip_address
+    type = "ssh"
+    user = var.sudo_user
+    private_key = file(var.private_key_file)
+  }
+}
+
+# Validate private interface is active
+resource "null_resource" "snaps-boot-verify-admin-priv-intfs" {
+  depends_on = [null_resource.snaps-boot-reinject-pub-key-to-build]
+
+  # Setup KVM on the VM to create VMs on it for testing snaps-boot
+  provisioner "local-exec" {
+    command = <<EOT
+${var.ANSIBLE_CMD} -u ${var.sudo_user} \
+-i ${var.build_ip_prfx}.${var.build_ip_suffix}, \
+${var.VERIFY_INTFS} \
+--ssh-common-args="-o ProxyCommand='ssh ${var.sudo_user}@${azurerm_public_ip.snaps-boot-pub-ip.ip_address} nc ${var.build_ip_prfx}.${var.build_ip_suffix} 22'" \
+--extra-vars "{
+'username': 'root',
+'host_ips': ['${var.admin_ip_prfx}.${var.node_1_suffix}',
+              '${var.admin_ip_prfx}.${var.node_2_suffix}',
+              '${var.admin_ip_prfx}.${var.node_3_suffix}',
+              '${var.pub_ip_prfx}.${var.node_1_suffix}',
+              '${var.pub_ip_prfx}.${var.node_2_suffix}',
+              '${var.pub_ip_prfx}.${var.node_3_suffix}',
+            ],
+'timeout': '${var.std_boot_timeout}',
+}"\
+EOT
+  }
+}
+
+# Validate private interface is active
+resource "null_resource" "snaps-boot-verify-apt-proxy-node-1" {
+  depends_on = [null_resource.snaps-boot-verify-admin-priv-intfs]
+
+  # Setup KVM on the VM to create VMs on it for testing snaps-boot
+  provisioner "local-exec" {
+    command = <<EOT
+${var.ANSIBLE_CMD} -u ${var.sudo_user} \
+-i ${var.build_ip_prfx}.${var.build_ip_suffix}, \
+${var.VERIFY_APT_PROXY} \
+--ssh-common-args="-o ProxyCommand='ssh ${var.sudo_user}@${azurerm_public_ip.snaps-boot-pub-ip.ip_address} nc ${var.build_ip_prfx}.${var.build_ip_suffix} 22'" \
+--extra-vars "{
+'username': 'root',
+'ip_addr': '${var.priv_ip_prfx}.${var.node_1_suffix}',
+}"\
+EOT
+  }
+}

--- a/ci/azure/variables.tf
+++ b/ci/azure/variables.tf
@@ -1,0 +1,82 @@
+# Copyright (c) 2019 Cable Television Laboratories, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Required Variables
+variable "build_id" {}
+
+variable "wait_timeout" {default = "600"}
+
+# Variables that are recommended to change as they won't work in all envs
+variable "public_key_file" {default = "~/.ssh/id_rsa.pub"}
+variable "private_key_file" {default = "~/.ssh/id_rsa"}
+
+# Playbook Constants
+variable "ANSIBLE_CMD" {default = "export ANSIBLE_HOST_KEY_CHECKING=False; ansible-playbook"}
+variable "WAIT_FOR_BUILD" {default = "../playbooks/wait_for_build.yaml"}
+variable "SETUP_SRC" {default = "../playbooks/setup_src.yaml"}
+variable "SETUP_DRP" {default = "../playbooks/setup_drp.yaml"}
+variable "VERIFY_INTFS" {default = "../playbooks/verify_intfs.yaml"}
+variable "VERIFY_APT_PROXY" {default = "../playbooks/verify_apt.yaml"}
+variable "CONFIG_INTFS" {default = "../playbooks/config_intfs.yaml"}
+variable "VERIFY_INTFS_CHECK_FILE" {default = "/var/log/hello_world"}
+
+# Optional Variables for test
+variable "src_copy_dir" {default = "/tmp"}
+variable "post_script_file" {default = "/tmp/snaps-boot/ci/scripts/post_script"}
+variable "hosts_yaml_path" {default = "/tmp/hosts.yaml"}
+
+# best to obtain from snaps-config/ci/snaps-boot-env/boot-env.tfvars
+variable "shared_resource_group_name" {}
+variable "built_image_id" {}
+variable "vm_size" {}
+variable "location" {}
+variable "initial_boot_timeout" {}
+variable "std_boot_timeout" {}
+variable "sudo_user" {}
+variable "volume_size" {}
+variable "netmask" {}
+variable "build_ip_prfx" {}
+variable "build_ip_bits" {}
+variable "build_ip_suffix" {}
+variable "build_net_name" {}
+variable "priv_ip_prfx" {}
+variable "priv_net_name" {}
+variable "admin_ip_prfx" {}
+variable "admin_net_name" {}
+variable "pub_ip_prfx" {}
+variable "pub_net_name" {}
+variable "build_nic" {}
+variable "build_vm_name" {}
+variable "build_password" {}
+variable "build_mac_0" {}
+variable "build_mac_1" {}
+variable "build_mac_2" {}
+variable "build_mac_3" {}
+variable "node_1_name" {}
+variable "node_2_name" {}
+variable "node_3_name" {}
+variable "node_1_mac_1" {}
+variable "node_1_mac_2" {}
+variable "node_1_mac_3" {}
+variable "node_2_mac_1" {}
+variable "node_2_mac_2" {}
+variable "node_2_mac_3" {}
+variable "node_3_mac_1" {}
+variable "node_3_mac_2" {}
+variable "node_3_mac_3" {}
+variable "node_1_suffix" {}
+variable "node_2_suffix" {}
+variable "node_3_suffix" {}
+variable "proxy_port" {}
+variable "ngcacher_proxy_port" {}
+variable "pxe_pass" {}

--- a/ci/playbooks/setup_src.yaml
+++ b/ci/playbooks/setup_src.yaml
@@ -20,24 +20,21 @@
   pre_tasks:
     - name: Wait for dpkg lock
       raw: |
-        sleep 10
         while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1 ; do
-          sleep 5
+          sleep 2
         done
 
     - name: Wait for apt lock
       raw: |
-        sleep 10
         while sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 ; do
-          sleep 5
+          sleep 2
         done
 
     - name: Wait for unattended-upgrades
       raw: |
-        sleep 10
         if [ -f /var/log/unattended-upgrades/unattended-upgrades.log ]; then
           while sudo fuser /var/log/unattended-upgrades/unattended-upgrades.log >/dev/null 2>&1 ; do
-            sleep 5
+            sleep 2
           done
         fi
 
@@ -64,20 +61,6 @@
           - "--exclude=venv"
           - "--exclude=.git/objects/pack"
           - "--exclude=ci/aws/terraform/.terraform"
-
-#    - name: apt update
-#      become: yes
-#      become_method: sudo
-#      become_user: root
-#      apt:
-#        update_cache: yes
-#      register: result_update
-#      until: result_update is not failed
-#      retries: 30
-#      delay: 5
-#    - fail:
-#        msg: result_update.stdout
-#      when: result_update is failed
 
     - name: Install python-pip
       become: yes

--- a/ci/playbooks/wait_for_build.yaml
+++ b/ci/playbooks/wait_for_build.yaml
@@ -22,7 +22,7 @@
       wait_for:
         host: "{{ host }}"
         port: 22
-        timeout: 300
+        timeout: "{{ timeout }}"
 
     - name: Pause {{ pause_time | default(60) }} seconds due to some timing issues
       pause:


### PR DESCRIPTION
#### What does this PR do?
Fixes #293 
Adds option to run CI on Azure VMs.

#### Do you have any concerns with this PR?
The Azure cli must be installed and cloud credentials must be manually entered and stored on the terraform host. This PR won't break anything but Azure just is not ready for prime-time. All said, this patch should not break our current ci.

#### How can the reviewer verify this PR?
run the Azure CI scripts

#### Any background context you want to provide?
As AWS does not support nested VMs, we were forced to run CI on metal instances. Azure supports nested virtualization so this may be a cheaper option

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
yes
- Does the documentation need an update?
probably
- Does this add new Python dependencies?
no
- Have you added unit or functional tests for this PR?
no
- Does this patch update any configuration files?
no